### PR TITLE
Do not inherit from Struct

### DIFF
--- a/lib/droplet_kit/models/network.rb
+++ b/lib/droplet_kit/models/network.rb
@@ -1,4 +1,3 @@
 module DropletKit
-  class Network < Struct.new(:ip_address, :netmask, :gateway, :type, :cidr)
-  end
+  Network = Struct.new(:ip_address, :netmask, :gateway, :type, :cidr)
 end

--- a/lib/droplet_kit/models/network_hash.rb
+++ b/lib/droplet_kit/models/network_hash.rb
@@ -1,4 +1,3 @@
 module DropletKit
-  class NetworkHash < Struct.new(:v4, :v6)
-  end
+  NetworkHash = Struct.new(:v4, :v6)
 end


### PR DESCRIPTION
Just better practice to not inherit from Struct. Not much changes but the ancestor chain is cleaner.

``` ruby
class A < Struct.new(:x); end
B = Struct.new(:x)

A.ancestors
# => [A, #<Class:0x007f9ba12cd168>, Struct, Enumerable, Object, Kernel, BasicObject]
B.ancestors
# => [B, Struct, Enumerable, Object, Kernel, BasicObject]
```
