### PR TITLE
Add required Ruby version to gemspec

### DIFF
--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency 'virtus', '~> 1.0.3'
   spec.add_dependency "resource_kit", '~> 0.1.1'


### PR DESCRIPTION
With the addition of some keyword arguments, droplet_kit will now require at least ruby 2.0.0.
