### PR TITLE
Allow use of ActiveSupport 4.2

### DIFF
--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0.3'
   spec.add_dependency "resource_kit", '~> 0.1.1'
   spec.add_dependency "kartograph", '~> 0.2.0'
-  spec.add_dependency "activesupport", '~> 4.1.6'
+  spec.add_dependency "activesupport", '~> 4.2.0'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0.3'
   spec.add_dependency "resource_kit", '~> 0.1.1'
   spec.add_dependency "kartograph", '~> 0.2.0'
-  spec.add_dependency "activesupport", '~> 4.2.0'
+  spec.add_dependency "activesupport", '>= 4.0'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I upgraded a Rails application to 4.2 and my version of `DropletKit` downgraded to `1.0.1` which doesn't have support for some things I was using.

A few thoughts I'm having:

- Is ActiveSupport absolutely positively needed? If not, let's remove it!
- Can we have looser versioning constraints on ActiveSupport?

Happy Holidays.