### PR TITLE
It's **DigitalOcean**

### DIFF
--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = DropletKit::VERSION
   spec.authors       = ["Robert Ross"]
   spec.email         = ["rross@digitalocean.com"]
-  spec.summary       = %q{Droplet Kit is the official Ruby library for Digital Ocean's API}
-  spec.description   = %q{Droplet Kit is the official Ruby library for Digital Ocean's API}
+  spec.summary       = %q{Droplet Kit is the official Ruby library for DigitalOcean's API}
+  spec.description   = %q{Droplet Kit is the official Ruby library for DigitalOcean's API}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
This doesn't show up if you search for DigitalOcean on Ruby gems. As slackbot would tell you, it's **DigitalOcean**