### PR TITLE
Add faraday to dependencies.

### DIFF
--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -17,13 +17,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  
+
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency 'virtus', '~> 1.0.3'
   spec.add_dependency "resource_kit", '~> 0.1.1'
   spec.add_dependency "kartograph", '~> 0.2.0'
   spec.add_dependency "activesupport", '~> 4.1.6'
+  spec.add_dependency "faraday", '~> 0.9.1'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
We relied on ResourceKit bringing in Faraday but that has changed since it doesn't actually need it. This brings in the requirement for dropletkit.