### PR TITLE
Fix SshKeyMapping scopes - should be arrays.

### DIFF
--- a/lib/droplet_kit/mappings/ssh_key_mapping.rb
+++ b/lib/droplet_kit/mappings/ssh_key_mapping.rb
@@ -7,11 +7,11 @@ module DropletKit
       root_key singular: 'ssh_key', plural: 'ssh_keys', scopes: [:read]
 
       property :id, :fingerprint, :public_key, :name,
-        scopes: :read
+        scopes: [:read]
 
-      property :name, :public_key, scopes: :create
+      property :name, :public_key, scopes: [:create]
 
-      property :name, scopes: :update
+      property :name, scopes: [:update]
     end
   end
 end


### PR DESCRIPTION
Fixes the build. Looks like upgrading to kartograph 0.2.1 exposed this.

Ref: https://travis-ci.org/digitalocean/droplet_kit/jobs/53480175