### PR TITLE
Add support for region_slug

### DIFF
--- a/lib/droplet_kit/mappings/action_mapping.rb
+++ b/lib/droplet_kit/mappings/action_mapping.rb
@@ -14,6 +14,7 @@ module DropletKit
       property :resource_id, scopes: [:read]
       property :resource_type, scopes: [:read]
       property :region, scopes: [:read]
+      property :region_slug, scopes: [:read]
     end
   end
 end

--- a/lib/droplet_kit/mappings/image_action_mapping.rb
+++ b/lib/droplet_kit/mappings/image_action_mapping.rb
@@ -14,6 +14,7 @@ module DropletKit
       property :resource_id, scopes: [:read]
       property :resource_type, scopes: [:read]
       property :region, scopes: [:read]
+      property :region_slug, scopes: [:read]
     end
   end
 end

--- a/lib/droplet_kit/models/action.rb
+++ b/lib/droplet_kit/models/action.rb
@@ -8,5 +8,6 @@ module DropletKit
     attribute :resource_id
     attribute :resource_type
     attribute :region
+    attribute :region_slug
   end
 end

--- a/lib/droplet_kit/models/image_action.rb
+++ b/lib/droplet_kit/models/image_action.rb
@@ -8,5 +8,6 @@ module DropletKit
     attribute :resource_id
     attribute :resource_type
     attribute :region
+    attribute :region_slug
   end
 end

--- a/spec/fixtures/actions/all.json
+++ b/spec/fixtures/actions/all.json
@@ -8,7 +8,8 @@
       "completed_at": null,
       "resource_id": null,
       "resource_type": "backend",
-      "region": "nyc1"
+      "region": "nyc1",
+      "region_slug": "nyc1"
     }
   ],
   "meta": {

--- a/spec/fixtures/actions/find.json
+++ b/spec/fixtures/actions/find.json
@@ -7,6 +7,7 @@
     "completed_at": null,
     "resource_id": null,
     "resource_type": "backend",
-    "region": "nyc1"
+    "region": "nyc1",
+    "region_slug": "nyc1"
   }
 }

--- a/spec/fixtures/droplets/list_actions.json
+++ b/spec/fixtures/droplets/list_actions.json
@@ -8,7 +8,8 @@
       "completed_at": null,
       "resource_id": 24,
       "resource_type": "droplet",
-      "region": "nyc1"
+      "region": "nyc1",
+      "region_slug": "nyc1"
     }
   ],
   "meta": {

--- a/spec/fixtures/image_actions/all.json
+++ b/spec/fixtures/image_actions/all.json
@@ -8,7 +8,8 @@
             "completed_at": "2014-10-28T17:11:06Z",
             "resource_id": 45646587,
             "resource_type": "image",
-            "region": null
+            "region": null,
+            "region_slug": null
         },
         {
             "id": 234598,
@@ -18,7 +19,8 @@
             "completed_at": "2014-10-28T17:12:04Z",
             "resource_id": 45646587,
             "resource_type": "image",
-            "region": "nyc2"
+            "region": "nyc2",
+            "region_slug": "nyc2"
         }
     ],
     "links": {},

--- a/spec/fixtures/image_actions/create.json
+++ b/spec/fixtures/image_actions/create.json
@@ -7,6 +7,7 @@
     "completed_at": null,
     "resource_id": 449676391,
     "resource_type": "image",
-    "region": "nyc1"
+    "region": "nyc1",
+    "region_slug": "nyc1"
   }
 }

--- a/spec/fixtures/image_actions/find.json
+++ b/spec/fixtures/image_actions/find.json
@@ -7,6 +7,7 @@
     "completed_at": null,
     "resource_id": 449676391,
     "resource_type": "image",
-    "region": "nyc1"
+    "region": "nyc1",
+    "region_slug": "nyc1"
   }
 }

--- a/spec/lib/droplet_kit/resources/action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/action_resource_spec.rb
@@ -12,6 +12,23 @@ RSpec.describe DropletKit::ActionResource do
 
       expect(resource.all).to eq(expected_actions)
     end
+
+    it 'returns a list of correctly mapped actions' do
+      response = api_fixture('actions/all')
+      stub_do_api('/v2/actions', :get).to_return(body: response)
+      actions = resource.all
+
+      expect(actions.first).to be_kind_of(DropletKit::Action)
+      expect(actions.first.id).to eq(1)
+      expect(actions.first.status).to eq("in-progress")
+      expect(actions.first.type).to eq("test")
+      expect(actions.first.started_at).to eq("2014-07-29T14:35:26Z")
+      expect(actions.first.completed_at).to eq(nil)
+      expect(actions.first.resource_id).to eq(nil)
+      expect(actions.first.resource_type).to eq("backend")
+      expect(actions.first.region).to eq("nyc1")
+      expect(actions.first.region_slug).to eq("nyc1")
+    end
   end
 
   describe '#find' do
@@ -21,6 +38,23 @@ RSpec.describe DropletKit::ActionResource do
       expected_action = DropletKit::ActionMapping.extract_single(response, :read)
 
       expect(resource.find(id: 123)).to eq(expected_action)
+    end
+
+    it 'returns a correctly mapped action' do
+      response = api_fixture('actions/find')
+      stub_do_api('/v2/actions/123', :get).to_return(body: response)
+      action = resource.find(id: 123)
+
+      expect(action).to be_kind_of(DropletKit::Action)
+      expect(action.id).to eq(2)
+      expect(action.status).to eq("in-progress")
+      expect(action.type).to eq("test")
+      expect(action.started_at).to eq("2014-07-29T14:35:27Z")
+      expect(action.completed_at).to eq(nil)
+      expect(action.resource_id).to eq(nil)
+      expect(action.resource_type).to eq("backend")
+      expect(action.region).to eq("nyc1")
+      expect(action.region_slug).to eq("nyc1")
     end
   end
 end

--- a/spec/lib/droplet_kit/resources/droplet_action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_action_resource_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe DropletKit::DropletActionResource do
         "completed_at" => nil,
         "resource_id" => 12,
         "resource_type" => "droplet",
-        "region" => "nyc1"
+        "region" => "nyc1",
+        "region_slug" => "nyc1"
       }
     }.to_json
   end
@@ -161,6 +162,7 @@ RSpec.describe DropletKit::DropletActionResource do
       expect(returned_action.resource_id).to eq(nil)
       expect(returned_action.resource_type).to eq("backend")
       expect(returned_action.region).to eq("nyc1")
+      expect(returned_action.region_slug).to eq("nyc1")
     end
   end
 end

--- a/spec/lib/droplet_kit/resources/image_action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/image_action_resource_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe DropletKit::ImageActionResource do
       expect(action.resource_id).to eq(449676391)
       expect(action.resource_type).to eq("image")
       expect(action.region).to eq("nyc1")
+      expect(action.region_slug).to eq("nyc1")
     end
   end
 
@@ -49,6 +50,7 @@ RSpec.describe DropletKit::ImageActionResource do
       expect(action.resource_id).to eq(45646587)
       expect(action.resource_type).to eq("image")
       expect(action.region).to eq(nil)
+      expect(action.region_slug).to eq(nil)
     end
   end
 
@@ -66,6 +68,7 @@ RSpec.describe DropletKit::ImageActionResource do
       expect(action.resource_id).to eq(449676391)
       expect(action.resource_type).to eq("image")
       expect(action.region).to eq("nyc1")
+      expect(action.region_slug).to eq("nyc1")
     end
   end
 end


### PR DESCRIPTION
This adds in support for `region_slug` as in interim upgrade before the breaking change for embedded regions.

Builds on https://github.com/digitalocean/droplet_kit/pull/35

cc @phillbaker 