### PR TITLE
Separate Droplet model from DropletCreate model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ When you'd like to save objects, it's your responsibility to instantiate the obj
 
 ```ruby
 client = DropletKit::Client.new(access_token: 'YOUR_TOKEN')
-droplet = DropletKit::Droplet.new(name: 'mysite.com', region: 'nyc2', image: 'ubuntu-14-04-x64', size: '512mb')
-created = client.droplets.create(droplet)
+create_params = DropletKit::DropletCreate.new(name: 'mysite.com', region: 'nyc2', image: 'ubuntu-14-04-x64', size: '512mb')
+droplet = client.droplets.create(create_params)
 # => DropletKit::Droplet(id: 1231, name: 'something.com', ...)
 ```
 
@@ -59,7 +59,7 @@ To retrieve objects, you can perform this type of action on the resource (if the
 ```ruby
 client = DropletKit::Client.new(access_token: 'YOUR_TOKEN')
 droplet = client.droplets.find(id: 123)
-# => DropletKit::Droplet(id: 1231, name: 'something.com', ...)
+# => DropletKit::DropletCreate(id: 1231, name: 'something.com', ...)
 ```
 
 # All Resources and actions.

--- a/lib/droplet_kit.rb
+++ b/lib/droplet_kit.rb
@@ -9,6 +9,8 @@ module DropletKit
   # Models
   autoload :BaseModel, 'droplet_kit/models/base_model'
   autoload :Droplet, 'droplet_kit/models/droplet'
+  autoload :DropletCreate, 'droplet_kit/models/droplet_create'
+  autoload :Error, 'droplet_kit/models/error'
   autoload :Region, 'droplet_kit/models/region'
   autoload :Image, 'droplet_kit/models/image'
   autoload :ImageAction, 'droplet_kit/models/image_action'
@@ -40,6 +42,7 @@ module DropletKit
 
   # JSON Maps
   autoload :DropletMapping, 'droplet_kit/mappings/droplet_mapping'
+  autoload :DropletCreateMapping, 'droplet_kit/mappings/droplet_create_mapping'
   autoload :ImageMapping, 'droplet_kit/mappings/image_mapping'
   autoload :RegionMapping, 'droplet_kit/mappings/region_mapping'
   autoload :SizeMapping, 'droplet_kit/mappings/size_mapping'

--- a/lib/droplet_kit/mappings/droplet_create_mapping.rb
+++ b/lib/droplet_kit/mappings/droplet_create_mapping.rb
@@ -1,0 +1,20 @@
+module DropletKit
+  class DropletCreateMapping
+    include Kartograph::DSL
+
+    kartograph do
+      mapping DropletCreate
+
+      # Create properties arent quite the same
+      property :name, scopes: [:create]
+      property :region, scopes: [:create]
+      property :size, scopes: [:create]
+      property :image, scopes: [:create]
+      property :ssh_keys, scopes: [:create]
+      property :backups, scopes: [:create]
+      property :ipv6, scopes: [:create]
+      property :user_data, scopes: [:create]
+      property :private_networking, scopes: [:create]
+    end
+  end
+end

--- a/lib/droplet_kit/mappings/droplet_mapping.rb
+++ b/lib/droplet_kit/mappings/droplet_mapping.rb
@@ -24,17 +24,6 @@ module DropletKit
       property :image, scopes: [:read], include: ImageMapping
       property :networks, scopes: [:read], include: NetworkMapping
       property :kernel, scopes: [:read], include: KernelMapping
-
-      # Create properties arent quite the same
-      property :name, scopes: [:create]
-      property :region, scopes: [:create]
-      property :size, scopes: [:create]
-      property :image, scopes: [:create]
-      property :ssh_keys, scopes: [:create]
-      property :backups, scopes: [:create]
-      property :ipv6, scopes: [:create]
-      property :user_data, scopes: [:create]
-      property :private_networking, scopes: [:create]
     end
   end
 end

--- a/lib/droplet_kit/mappings/error_mapping.rb
+++ b/lib/droplet_kit/mappings/error_mapping.rb
@@ -1,7 +1,5 @@
 module DropletKit
   class ErrorMapping
-    Error = Struct.new(:message, :id)
-
     include Kartograph::DSL
 
     kartograph do

--- a/lib/droplet_kit/models/droplet.rb
+++ b/lib/droplet_kit/models/droplet.rb
@@ -6,14 +6,6 @@ module DropletKit
       attribute(key)
     end
 
-    # Used for creates
-    attribute :ssh_keys
-    attribute :backups
-    attribute :size
-    attribute :ipv6
-    attribute :user_data
-    attribute :private_networking
-
     def public_ip
       network = network_for(:v4, 'public')
       network && network.ip_address

--- a/lib/droplet_kit/models/droplet_create.rb
+++ b/lib/droplet_kit/models/droplet_create.rb
@@ -1,0 +1,13 @@
+module DropletKit
+  class DropletCreate < BaseModel
+    attribute :name
+    attribute :region
+    attribute :size
+    attribute :image
+    attribute :ssh_keys
+    attribute :backups
+    attribute :ipv6
+    attribute :user_data
+    attribute :private_networking
+  end
+end

--- a/lib/droplet_kit/models/error.rb
+++ b/lib/droplet_kit/models/error.rb
@@ -1,0 +1,3 @@
+module DropletKit
+  Error = Struct.new(:message, :id)
+end

--- a/lib/droplet_kit/resources/droplet_resource.rb
+++ b/lib/droplet_kit/resources/droplet_resource.rb
@@ -11,7 +11,7 @@ module DropletKit
       end
 
       action :create, 'POST /v2/droplets' do
-        body { |object| DropletMapping.representation_for(:create, object) }
+        body { |object| DropletCreateMapping.representation_for(:create, object) }
         handler(202) { |response| DropletMapping.extract_single(response.body, :read) }
         handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
       end

--- a/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe DropletKit::DropletResource do
   describe '#create' do
     context 'for a successful create' do
       it 'returns the created droplet' do
-        droplet = DropletKit::Droplet.new(
+        droplet = DropletKit::DropletCreate.new(
           name: 'test.example.com',
           region: 'nyc1',
           size: '512mb',
@@ -101,7 +101,7 @@ RSpec.describe DropletKit::DropletResource do
           user_data: "#cloud-config\nruncmd\n\t- echo 'Hello!'"
         )
 
-        as_hash = DropletKit::DropletMapping.representation_for(:create, droplet, NullHashLoad)
+        as_hash = DropletKit::DropletCreateMapping.representation_for(:create, droplet, NullHashLoad)
         expect(as_hash[:name]).to eq(droplet.name)
         expect(as_hash[:region]).to eq(droplet.region)
         expect(as_hash[:size]).to eq(droplet.size)
@@ -112,7 +112,7 @@ RSpec.describe DropletKit::DropletResource do
         expect(as_hash[:private_networking]).to eq(droplet.private_networking)
         expect(as_hash[:user_data]).to eq(droplet.user_data)
 
-        as_string = DropletKit::DropletMapping.representation_for(:create, droplet)
+        as_string = DropletKit::DropletCreateMapping.representation_for(:create, droplet)
         stub_do_api('/v2/droplets', :post).with(body: as_string).to_return(body: api_fixture('droplets/create'), status: 202)
         created_droplet = resource.create(droplet)
         check_droplet(created_droplet)
@@ -124,7 +124,7 @@ RSpec.describe DropletKit::DropletResource do
         response_body = { id: :unprocessable_entity, message: 'Something is not right' }
         stub_do_api('/v2/droplets', :post).to_return(body: response_body.to_json, status: 422)
 
-        expect { resource.create(DropletKit::Droplet.new) }.to raise_exception(DropletKit::FailedCreate).with_message(response_body[:message])
+        expect { resource.create(DropletKit::DropletCreate.new) }.to raise_exception(DropletKit::FailedCreate).with_message(response_body[:message])
       end
     end
   end


### PR DESCRIPTION
This came up a while back - passing the Droplet model into the create and then not having the same object updated with the return values. This follows the go client's approach of separating the types out.

Closes #51.

cc @nanzhong 