### PR TITLE
Spec cleanups - pagination

### DIFF
--- a/lib/droplet_kit/resources/droplet_upgrade_resource.rb
+++ b/lib/droplet_kit/resources/droplet_upgrade_resource.rb
@@ -2,7 +2,6 @@ module DropletKit
   class DropletUpgradeResource < ResourceKit::Resource
     resources do
       action :all, 'GET /v2/droplet_upgrades' do
-        query_keys :per_page, :page
         handler(200) { |response| DropletUpgradeMapping.extract_collection(response.body, :read) }
       end
     end

--- a/spec/lib/droplet_kit/resources/action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/action_resource_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe DropletKit::ActionResource do
       expect(actions.first.region.available).to be(true)
       expect(actions.first.region.features).to include("virtio", "private_networking", "backups", "ipv6", "metadata")
     end
+
+    it_behaves_like 'a paginated index' do
+      let(:fixture_path) { 'actions/all' }
+      let(:api_path) { '/v2/actions' }
+    end
   end
 
   describe '#find' do

--- a/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
@@ -75,6 +75,11 @@ RSpec.describe DropletKit::DropletResource do
       droplets = resource.all.map(&:id)
       expect(droplets).to be_empty
     end
+
+    it_behaves_like 'a paginated index' do
+      let(:fixture_path) { 'droplets/all' }
+      let(:api_path) { '/v2/droplets' }
+    end
   end
 
   describe '#find' do
@@ -143,6 +148,12 @@ RSpec.describe DropletKit::DropletResource do
       expect(kernels[1].name).to eq('Ubuntu 14.04 x64 vmlinuz-3.13.0-24-generic (1221)')
       expect(kernels[1].version).to eq('3.13.0-24-generic')
     end
+
+    it 'returns a paginated resource' do
+      stub_do_api('/v2/droplets/1066/kernels', :get).to_return(body: api_fixture('droplets/list_kernels'))
+      kernels = resource.kernels(id: 1066, page: 1, per_page: 1)
+      expect(kernels).to be_kind_of(DropletKit::PaginatedResource)
+    end
   end
 
   describe '#snapshots' do
@@ -159,6 +170,12 @@ RSpec.describe DropletKit::DropletResource do
       expect(snapshots[0].regions).to eq(["nyc1"])
       expect(snapshots[0].created_at).to eq("2014-07-29T14:35:38Z")
     end
+
+    it 'returns a paginated resource' do
+      stub_do_api('/v2/droplets/1066/snapshots', :get).to_return(body: api_fixture('droplets/list_snapshots'))
+      snapshots = resource.snapshots(id: 1066, page: 1, per_page: 1)
+      expect(snapshots).to be_kind_of(DropletKit::PaginatedResource)
+    end
   end
 
   describe '#backups' do
@@ -174,6 +191,12 @@ RSpec.describe DropletKit::DropletResource do
       expect(backups[0].public).to eq(false)
       expect(backups[0].regions).to eq(["nyc1"])
       expect(backups[0].created_at).to eq("2014-07-29T14:35:38Z")
+    end
+
+    it 'returns a paginated resource' do
+      stub_do_api('/v2/droplets/1066/backups', :get).to_return(body: api_fixture('droplets/list_backups'))
+      backups = resource.backups(id: 1066, page: 1, per_page: 1)
+      expect(backups).to be_kind_of(DropletKit::PaginatedResource)
     end
   end
 
@@ -197,6 +220,12 @@ RSpec.describe DropletKit::DropletResource do
       expect(actions[0].region.sizes).to include('512mb')
       expect(actions[0].region.available).to be(true)
       expect(actions[0].region.features).to include("virtio", "private_networking", "backups", "ipv6", "metadata")
+    end
+
+    it 'returns a paginated resource' do
+      stub_do_api('/v2/droplets/1066/actions', :get).to_return(body: api_fixture('droplets/list_actions'))
+      actions = resource.actions(id: 1066, page: 1, per_page: 1)
+      expect(actions).to be_kind_of(DropletKit::PaginatedResource)
     end
   end
 

--- a/spec/lib/droplet_kit/resources/image_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/image_resource_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe DropletKit::ImageResource do
 
       expect(resource.all(type: :application)).to eq(expected_images)
     end
+
+    it_behaves_like 'a paginated index' do
+      let(:fixture_path) { 'images/all' }
+      let(:api_path) { '/v2/images' }
+    end
   end
 
   describe '#find' do

--- a/spec/support/shared_examples/paginated_endpoint.rb
+++ b/spec/support/shared_examples/paginated_endpoint.rb
@@ -1,0 +1,13 @@
+# To use this, `fixture_path`, `api_path` and a `resource` must be defined
+# using `let`s.
+shared_examples_for 'a paginated index' do
+  let(:fixture_path) { }
+  let(:api_path) { }
+
+  it 'returns a paginated resource' do
+    fixture = api_fixture(fixture_path)
+    stub_do_api(api_path, :get).to_return(body: fixture)
+    response = resource.all(page: 1, per_page: 1)
+    expect(response).to be_kind_of(DropletKit::PaginatedResource)
+  end
+end


### PR DESCRIPTION
* Adds a shared example for paginated indexes for use in https://github.com/digitalocean/droplet_kit/pull/54. 
* Remove page query keys from DropletUpgradeResource, not supported.

cc @nanzhong @bobbytables 