### PR TITLE
Add floating ips and floating ip actions support.

### DIFF
--- a/lib/droplet_kit.rb
+++ b/lib/droplet_kit.rb
@@ -25,6 +25,7 @@ module DropletKit
   autoload :MetaInformation, 'droplet_kit/models/meta_information'
   autoload :Account, 'droplet_kit/models/account'
   autoload :DropletUpgrade, 'droplet_kit/models/droplet_upgrade'
+  autoload :FloatingIp, 'droplet_kit/models/floating_ip'
 
   # Resources
   autoload :DropletResource, 'droplet_kit/resources/droplet_resource'
@@ -39,6 +40,8 @@ module DropletKit
   autoload :SizeResource, 'droplet_kit/resources/size_resource'
   autoload :AccountResource, 'droplet_kit/resources/account_resource'
   autoload :DropletUpgradeResource, 'droplet_kit/resources/droplet_upgrade_resource'
+  autoload :FloatingIpResource, 'droplet_kit/resources/floating_ip_resource'
+  autoload :FloatingIpActionResource, 'droplet_kit/resources/floating_ip_action_resource'
 
   # JSON Maps
   autoload :DropletMapping, 'droplet_kit/mappings/droplet_mapping'
@@ -58,7 +61,7 @@ module DropletKit
   autoload :SSHKeyMapping, 'droplet_kit/mappings/ssh_key_mapping'
   autoload :AccountMapping, 'droplet_kit/mappings/account_mapping'
   autoload :DropletUpgradeMapping, 'droplet_kit/mappings/droplet_upgrade_mapping'
-
+  autoload :FloatingIpMapping, 'droplet_kit/mappings/floating_ip_mapping'
 
   # Utils
   autoload :PaginatedResource, 'droplet_kit/paginated_resource'

--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -29,6 +29,8 @@ module DropletKit
         sizes: SizeResource,
         ssh_keys: SSHKeyResource,
         account: AccountResource,
+        floating_ips: FloatingIpResource,
+        floating_ip_actions: FloatingIpActionResource,
       }
     end
 

--- a/lib/droplet_kit/mappings/floating_ip_mapping.rb
+++ b/lib/droplet_kit/mappings/floating_ip_mapping.rb
@@ -1,0 +1,19 @@
+module DropletKit
+  class FloatingIpMapping
+    include Kartograph::DSL
+
+    kartograph do
+      mapping FloatingIp
+      root_key plural: 'floating_ips', singular: 'floating_ip', scopes: [:read]
+
+      property :ip, scopes: [:read]
+
+      property :region, scopes: [:read], include: RegionMapping
+      property :droplet, scopes: [:read], include: DropletMapping
+
+      # Create properties aren't quite the same
+      property :droplet_id, scopes: [:create]
+      property :region, scopes: [:create]
+    end
+  end
+end

--- a/lib/droplet_kit/models/floating_ip.rb
+++ b/lib/droplet_kit/models/floating_ip.rb
@@ -1,0 +1,10 @@
+module DropletKit
+  class FloatingIp < BaseModel
+    attribute :ip
+    attribute :region
+    attribute :droplet
+
+    # Used for creates
+    attribute :droplet_id
+  end
+end

--- a/lib/droplet_kit/resources/floating_ip_action_resource.rb
+++ b/lib/droplet_kit/resources/floating_ip_action_resource.rb
@@ -1,0 +1,30 @@
+module DropletKit
+  class FloatingIpActionResource < ResourceKit::Resource
+    resources do
+      default_handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
+
+      action :assign, 'POST /v2/floating_ips/:ip/actions' do
+        body { |hash| { type: 'assign', droplet_id: hash[:droplet_id] }.to_json }
+        handler(201, 200) { |response| ActionMapping.extract_single(response.body, :read) }
+      end
+
+      action :unassign, 'POST /v2/floating_ips/:ip/actions' do
+        body { |hash| { type: 'unassign' }.to_json }
+        handler(201, 200) { |response| ActionMapping.extract_single(response.body, :read) }
+      end
+
+      action :find, 'GET /v2/floating_ips/:ip/actions/:id' do
+        handler(200) { |response| ActionMapping.extract_single(response.body, :read) }
+      end
+
+      action :all, 'GET /v2/floating_ips/:ip/actions' do
+        query_keys :per_page, :page
+        handler(200) { |response| ActionMapping.extract_collection(response.body, :read) }
+      end
+    end
+
+    def all(*args)
+      PaginatedResource.new(action(:all), self, *args)
+    end
+  end
+end

--- a/lib/droplet_kit/resources/floating_ip_resource.rb
+++ b/lib/droplet_kit/resources/floating_ip_resource.rb
@@ -1,0 +1,29 @@
+module DropletKit
+  class FloatingIpResource < ResourceKit::Resource
+    resources do
+      action :all, 'GET /v2/floating_ips' do
+        query_keys :per_page, :page
+        handler(200) { |response| FloatingIpMapping.extract_collection(response.body, :read) }
+      end
+
+      action :find, 'GET /v2/floating_ips/:ip' do
+        handler(200) { |response| FloatingIpMapping.extract_single(response.body, :read) }
+      end
+
+      action :create, 'POST /v2/floating_ips' do
+        body { |object| FloatingIpMapping.representation_for(:create, object) }
+        handler(202) { |response| FloatingIpMapping.extract_single(response.body, :read) }
+        handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
+      end
+
+      action :delete, 'DELETE /v2/floating_ips/:ip' do
+        handler(202) { |response| ActionMapping.extract_single(response.body, :read) }
+        handler(204) { |response| true }
+      end
+    end
+
+    def all(*args)
+      PaginatedResource.new(action(:all), self, *args)
+    end
+  end
+end

--- a/spec/fixtures/floating_ip_actions/all.json
+++ b/spec/fixtures/floating_ip_actions/all.json
@@ -1,0 +1,41 @@
+{
+  "actions": [
+    {
+      "id": 19,
+      "status": "completed",
+      "type": "assign_ip",
+      "started_at": "2014-10-28T17:11:05Z",
+      "completed_at": "2014-10-28T17:11:06Z",
+      "resource_id": 45646587,
+      "resource_type": "floating_ip",
+      "region_slug": "nyc1",
+      "region": {
+        "name": "New York",
+        "slug": "nyc1",
+        "available": true,
+        "sizes": ["512mb"],
+        "features": ["virtio", "private_networking", "backups", "ipv6", "metadata"]
+      }
+    },
+    {
+      "id": 20,
+      "status": "completed",
+      "type": "release_ip",
+      "started_at": "2014-10-28T17:11:05Z",
+      "completed_at": "2014-10-28T17:11:06Z",
+      "resource_id": 45646587,
+      "resource_type": "floating_ip",
+      "region_slug": "nyc1",
+      "region": {
+        "name": "New York",
+        "slug": "nyc1",
+        "available": true,
+        "sizes": ["512mb"],
+        "features": ["virtio", "private_networking", "backups", "ipv6", "metadata"]
+      }
+    }
+  ],
+  "meta": {
+    "total": 2
+  }
+}

--- a/spec/fixtures/floating_ip_actions/assign.json
+++ b/spec/fixtures/floating_ip_actions/assign.json
@@ -1,0 +1,27 @@
+{
+  "action": {
+    "id": 2,
+    "status": "in-progress",
+    "type": "assign",
+    "started_at": "2014-08-05T15:15:28Z",
+    "completed_at": null,
+    "resource_id": 12,
+    "resource_type": "floating_ip",
+    "region_slug": "nyc1",
+    "region": {
+      "name": "New York",
+      "slug": "nyc1",
+      "available": true,
+      "sizes": [
+        "512mb"
+      ],
+      "features": [
+        "virtio",
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ]
+    }
+  }
+}

--- a/spec/fixtures/floating_ip_actions/find.json
+++ b/spec/fixtures/floating_ip_actions/find.json
@@ -1,0 +1,19 @@
+{
+  "action": {
+    "id": 19,
+    "status": "completed",
+    "type": "assign_ip",
+    "started_at": "2014-10-28T17:11:05Z",
+    "completed_at": "2014-10-28T17:11:06Z",
+    "resource_id": 45646587,
+    "resource_type": "floating_ip",
+    "region_slug": "nyc1",
+    "region": {
+      "name": "New York",
+      "slug": "nyc1",
+      "available": true,
+      "sizes": ["512mb"],
+      "features": ["virtio", "private_networking", "backups", "ipv6", "metadata"]
+    }
+  }
+}

--- a/spec/fixtures/floating_ip_actions/unassign.json
+++ b/spec/fixtures/floating_ip_actions/unassign.json
@@ -1,0 +1,27 @@
+{
+  "action": {
+    "id": 2,
+    "status": "in-progress",
+    "type": "unassign",
+    "started_at": "2014-08-05T15:15:28Z",
+    "completed_at": null,
+    "resource_id": 12,
+    "resource_type": "floating_ip",
+    "region_slug": "nyc1",
+    "region": {
+      "name": "New York",
+      "slug": "nyc1",
+      "available": true,
+      "sizes": [
+        "512mb"
+      ],
+      "features": [
+        "virtio",
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ]
+    }
+  }
+}

--- a/spec/fixtures/floating_ips/all.json
+++ b/spec/fixtures/floating_ips/all.json
@@ -1,0 +1,186 @@
+{
+  "floating_ips": [
+    {
+      "ip": "45.55.96.32",
+      "region": {
+        "available": true,
+        "features": [
+          "private_networking",
+          "backups",
+          "ipv6",
+          "metadata"
+        ],
+        "sizes": [
+          "512mb",
+          "1gb",
+          "2gb",
+          "4gb",
+          "8gb",
+          "16gb",
+          "32gb",
+          "48gb",
+          "64gb"
+        ],
+        "slug": "nyc3",
+        "name": "New York 3"
+      },
+      "droplet": {
+        "region": {
+          "available": true,
+          "features": [
+            "private_networking",
+            "backups",
+            "ipv6",
+            "metadata"
+          ],
+          "sizes": [
+            "512mb",
+            "1gb",
+            "2gb",
+            "4gb",
+            "8gb",
+            "16gb",
+            "32gb",
+            "48gb",
+            "64gb"
+          ],
+          "slug": "nyc3",
+          "name": "New York 3"
+        },
+        "networks": {
+          "v6": [],
+          "v4": [
+            {
+              "type": "public",
+              "gateway": "104.131.0.1",
+              "netmask": "255.255.192.0",
+              "ip_address": "104.131.39.129"
+            }
+          ]
+        },
+        "kernel": {
+          "version": "3.13.0-57-generic",
+          "name": "Ubuntu 14.04 x64 vmlinuz-3.13.0-57-generic",
+          "id": 5175
+        },
+        "status": "active",
+        "locked": false,
+        "disk": 20,
+        "vcpus": 1,
+        "memory": 512,
+        "name": "nyc3",
+        "id": 7173070,
+        "created_at": "2015-09-08T20:29:48Z",
+        "features": [
+          "virtio"
+        ],
+        "backup_ids": [],
+        "next_backup_window": null,
+        "snapshot_ids": [],
+        "image": {
+          "type": "snapshot",
+          "id": 13089493,
+          "name": "14.04 x64",
+          "distribution": "Ubuntu",
+          "slug": "ubuntu-14-04-x64",
+          "public": true,
+          "regions": [
+            "nyc1",
+            "ams1",
+            "sfo1",
+            "nyc2",
+            "ams2",
+            "sgp1",
+            "lon1",
+            "nyc3",
+            "ams3",
+            "fra1",
+            "tor1"
+          ],
+          "created_at": "2015-08-10T21:30:19Z",
+          "min_disk_size": 20
+        },
+        "size": {
+          "available": true,
+          "slug": "512mb",
+          "memory": 512,
+          "vcpus": 1,
+          "disk": 20,
+          "transfer": 1,
+          "price_monthly": 5,
+          "price_hourly": 0.00744,
+          "regions": [
+            "nyc1",
+            "sgp1",
+            "ams1",
+            "sfo1",
+            "nyc2",
+            "lon1",
+            "nyc3",
+            "ams3",
+            "ams2",
+            "fra1",
+            "tor1"
+          ]
+        },
+        "size_slug": "512mb"
+      }
+    },
+    {
+      "ip": "188.166.132.3",
+      "region": {
+        "available": true,
+        "features": [
+          "private_networking",
+          "backups",
+          "ipv6",
+          "metadata"
+        ],
+        "sizes": [
+          "512mb",
+          "1gb",
+          "2gb",
+          "4gb",
+          "8gb",
+          "16gb",
+          "32gb",
+          "48gb",
+          "64gb"
+        ],
+        "slug": "ams3",
+        "name": "Amsterdam 3"
+      },
+      "droplet": null
+    },
+    {
+      "ip": "45.55.96.3",
+      "region": {
+        "available": true,
+        "features": [
+          "private_networking",
+          "backups",
+          "ipv6",
+          "metadata"
+        ],
+        "sizes": [
+          "512mb",
+          "1gb",
+          "2gb",
+          "4gb",
+          "8gb",
+          "16gb",
+          "32gb",
+          "48gb",
+          "64gb"
+        ],
+        "slug": "nyc3",
+        "name": "New York 3"
+      },
+      "droplet": null
+    }
+  ],
+  "meta": {
+    "total": 3
+  },
+  "links": {}
+}

--- a/spec/fixtures/floating_ips/all_empty.json
+++ b/spec/fixtures/floating_ips/all_empty.json
@@ -1,0 +1,7 @@
+{
+  "floating_ips": [
+  ],
+  "meta": {
+    "total": 0
+  }
+}

--- a/spec/fixtures/floating_ips/create.json
+++ b/spec/fixtures/floating_ips/create.json
@@ -1,0 +1,29 @@
+{
+  "floating_ip": {
+    "ip": "45.55.96.32",
+    "region": {
+      "available": true,
+      "features": [
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ],
+      "sizes": [
+        "512mb",
+        "1gb",
+        "2gb",
+        "4gb",
+        "8gb",
+        "16gb",
+        "32gb",
+        "48gb",
+        "64gb"
+      ],
+      "slug": "nyc3",
+      "name": "New York 3"
+    },
+    "droplet": null,
+    "links": {}
+  }
+}

--- a/spec/fixtures/floating_ips/create_with_droplet.json
+++ b/spec/fixtures/floating_ips/create_with_droplet.json
@@ -1,0 +1,44 @@
+{
+  "floating_ip": {
+    "ip": "45.55.96.32",
+    "region": {
+      "available": true,
+      "features": [
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ],
+      "sizes": [
+        "512mb",
+        "1gb",
+        "2gb",
+        "4gb",
+        "8gb",
+        "16gb",
+        "32gb",
+        "48gb",
+        "64gb"
+      ],
+      "slug": "nyc3",
+      "name": "New York 3"
+    },
+    "droplet": null,
+    "links": {
+      "actions": [
+        {
+          "href": "https://api.digitalocean.com/v2/actions/66582085",
+          "rel": "assign_ip",
+          "id": 66582085
+        }
+      ],
+      "droplets": [
+        {
+          "href": "https://api.digitalocean.com/v2/droplets/7173070",
+          "rel": "droplet",
+          "id": 7173070
+        }
+      ]
+    }
+  }
+}

--- a/spec/fixtures/floating_ips/find.json
+++ b/spec/fixtures/floating_ips/find.json
@@ -1,0 +1,28 @@
+{
+  "floating_ip": {
+    "ip": "45.55.96.32",
+    "region": {
+      "available": true,
+      "features": [
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ],
+      "sizes": [
+        "512mb",
+        "1gb",
+        "2gb",
+        "4gb",
+        "8gb",
+        "16gb",
+        "32gb",
+        "48gb",
+        "64gb"
+      ],
+      "slug": "nyc3",
+      "name": "New York 3"
+    },
+    "droplet": null
+  }
+}

--- a/spec/lib/droplet_kit/resources/floating_ip_action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/floating_ip_action_resource_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+RSpec.describe DropletKit::FloatingIpActionResource do
+  subject(:resource) { described_class.new(connection: connection) }
+  include_context 'resources'
+
+  describe '#assign' do
+    let(:ip) { '127.0.0.1' }
+    let(:droplet_id) { 123 }
+    let(:path) { "/v2/floating_ips/#{ip}/actions" }
+    let(:action) { 'assign' }
+    let(:fixture) { api_fixture("floating_ip_actions/#{action}") }
+
+    it 'sends an assign request for a floating ip' do
+      request = stub_do_api(path).with(
+        body: { type: action, droplet_id: droplet_id }.to_json
+      ).to_return(body: fixture, status: 201)
+
+      action = resource.assign(ip: ip, droplet_id: droplet_id)
+
+      expect(request).to have_been_made
+
+      expect(action).to be_kind_of(DropletKit::Action)
+      expect(action.id).to eq(2)
+      expect(action.status).to eq("in-progress")
+      expect(action.type).to eq("assign")
+      expect(action.started_at).to eq("2014-08-05T15:15:28Z")
+      expect(action.completed_at).to eq(nil)
+      expect(action.resource_id).to eq(12)
+      expect(action.resource_type).to eq("floating_ip")
+      expect(action.region_slug).to eq("nyc1")
+
+      expect(action.region).to be_kind_of(DropletKit::Region)
+      expect(action.region.slug).to eq('nyc1')
+      expect(action.region.name).to eq('New York')
+      expect(action.region.sizes).to include('512mb')
+      expect(action.region.available).to be(true)
+      expect(action.region.features).to include("virtio", "private_networking", "backups", "ipv6", "metadata")
+    end
+
+    it_behaves_like 'an action that handles invalid parameters' do
+      let(:arguments) { { ip: ip, droplet_id: droplet_id } }
+    end
+  end
+
+  describe '#unassign' do
+    let(:ip) { '127.0.0.1' }
+    let(:path) { "/v2/floating_ips/#{ip}/actions" }
+    let(:action) { 'unassign' }
+    let(:fixture) { api_fixture("floating_ip_actions/#{action}") }
+
+    it 'sends an unassign request for a floating ip' do
+      request = stub_do_api(path).with(
+        body: { type: action }.to_json
+      ).to_return(body: fixture, status: 201)
+
+      action = resource.unassign(ip: ip)
+
+      expect(request).to have_been_made
+
+      expect(action).to be_kind_of(DropletKit::Action)
+      expect(action.id).to eq(2)
+      expect(action.status).to eq("in-progress")
+      expect(action.type).to eq("unassign")
+      expect(action.started_at).to eq("2014-08-05T15:15:28Z")
+      expect(action.completed_at).to eq(nil)
+      expect(action.resource_id).to eq(12)
+      expect(action.resource_type).to eq("floating_ip")
+      expect(action.region_slug).to eq("nyc1")
+
+      expect(action.region).to be_kind_of(DropletKit::Region)
+      expect(action.region.slug).to eq('nyc1')
+      expect(action.region.name).to eq('New York')
+      expect(action.region.sizes).to include('512mb')
+      expect(action.region.available).to be(true)
+      expect(action.region.features).to include("virtio", "private_networking", "backups", "ipv6", "metadata")
+    end
+
+    it_behaves_like 'an action that handles invalid parameters' do
+      let(:arguments) { { ip: ip } }
+    end
+  end
+
+  describe '#all' do
+    let(:ip) { '127.0.0.1' }
+
+    it 'returns all of the floating ip actions via a paginated resources' do
+      request = stub_do_api("/v2/floating_ips/#{ip}/actions", :get).to_return(
+        body: api_fixture('floating_ip_actions/all'),
+        status: 200
+      )
+
+      actions = resource.all(ip: ip).take(20)
+
+      expect(request).to have_been_made
+
+      expect(actions.size).to be(2)
+
+      action = actions.first
+
+      expect(action.id).to eq(19)
+      expect(action.status).to eq("completed")
+      expect(action.type).to eq("assign_ip")
+      expect(action.started_at).to eq("2014-10-28T17:11:05Z")
+      expect(action.completed_at).to eq("2014-10-28T17:11:06Z")
+      expect(action.resource_id).to eq(45646587)
+      expect(action.resource_type).to eq("floating_ip")
+      expect(action.region).to be_kind_of(DropletKit::Region)
+      expect(action.region_slug).to eq("nyc1")
+    end
+
+    it_behaves_like 'a paginated index' do
+      let(:fixture_path) { 'floating_ip_actions/all' }
+      let(:api_path) { "/v2/floating_ips/#{ip}/actions" }
+      let(:parameters) { { ip: ip } }
+    end
+  end
+
+  describe '#find' do
+    let(:ip) { '127.0.0.1' }
+
+    it 'returns a single action' do
+      stub_do_api("/v2/floating_ips/#{ip}/actions/23", :get).to_return(body: api_fixture('floating_ip_actions/find'))
+      action = resource.find(ip: ip, id: 23)
+
+      expect(action.id).to eq(19)
+      expect(action.status).to eq("completed")
+      expect(action.type).to eq("assign_ip")
+      expect(action.started_at).to eq("2014-10-28T17:11:05Z")
+      expect(action.completed_at).to eq("2014-10-28T17:11:06Z")
+      expect(action.resource_id).to eq(45646587)
+      expect(action.resource_type).to eq("floating_ip")
+      expect(action.region).to be_kind_of(DropletKit::Region)
+      expect(action.region_slug).to eq("nyc1")
+    end
+  end
+end

--- a/spec/lib/droplet_kit/resources/floating_ip_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/floating_ip_resource_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+RSpec.describe DropletKit::FloatingIpResource do
+  subject(:resource) { described_class.new(connection: connection) }
+  include_context 'resources'
+
+  RSpec::Matchers.define :match_floating_ip_fixture do |droplet|
+    match do |floating_ip|
+      expect(floating_ip.region).to be_kind_of(DropletKit::Region)
+      expect(floating_ip.droplet).to be_kind_of(DropletKit::Droplet) if droplet
+
+      floating_ip.ip == "45.55.96.32"
+    end
+  end
+
+  describe '#all' do
+    it 'returns all of the floating_ips' do
+      stub_do_api('/v2/floating_ips', :get).to_return(body: api_fixture('floating_ips/all'))
+      floating_ips = resource.all
+      expect(floating_ips).to all(be_kind_of(DropletKit::FloatingIp))
+
+      expect(floating_ips.first).to match_floating_ip_fixture
+    end
+
+    it 'returns an empty array of floating_ips' do
+      stub_do_api('/v2/floating_ips', :get).to_return(body: api_fixture('floating_ips/all_empty'))
+      floating_ips = resource.all.map(&:ip)
+      expect(floating_ips).to be_empty
+    end
+
+    it_behaves_like 'a paginated index' do
+      let(:fixture_path) { 'floating_ips/all' }
+      let(:api_path) { '/v2/floating_ips' }
+    end
+  end
+
+  describe '#find' do
+    it 'returns a singular floating_ip' do
+      stub_do_api('/v2/floating_ips/45.55.96.32', :get).to_return(body: api_fixture('floating_ips/find'))
+      floating_ip = resource.find(ip: "45.55.96.32")
+      expect(floating_ip).to be_kind_of(DropletKit::FloatingIp)
+      expect(floating_ip).to match_floating_ip_fixture
+    end
+  end
+
+  describe '#create' do
+    let(:path) { '/v2/floating_ips' }
+
+    context 'for a successful create' do
+      it 'returns the created floating_ip' do
+        floating_ip = DropletKit::FloatingIp.new(
+          region: 'nyc1'
+        )
+
+        as_string = DropletKit::FloatingIpMapping.representation_for(:create, floating_ip)
+        stub_do_api(path, :post).with(body: as_string).to_return(body: api_fixture('floating_ips/create'), status: 202)
+        created_floating_ip = resource.create(floating_ip)
+
+        expect(created_floating_ip).to match_floating_ip_fixture
+      end
+    end
+
+    context 'for a successful create with droplet' do
+      it 'returns the created floating_ip' do
+        floating_ip = DropletKit::FloatingIp.new(
+          droplet_id: 123
+        )
+
+        as_string = DropletKit::FloatingIpMapping.representation_for(:create, floating_ip)
+        stub_do_api(path, :post).with(body: as_string).to_return(body: api_fixture('floating_ips/create_with_droplet'), status: 202)
+        created_floating_ip = resource.create(floating_ip)
+
+        expect(created_floating_ip).to match_floating_ip_fixture
+      end
+    end
+
+    it_behaves_like 'an action that handles invalid parameters' do
+      let(:action) { 'create' }
+      let(:arguments) { DropletKit::FloatingIp.new }
+    end
+  end
+
+  describe '#delete' do
+    it 'sends a delete request for the floating_ip' do
+      request = stub_do_api('/v2/floating_ips/45.55.96.32', :delete)
+      resource.delete(ip: "45.55.96.32")
+
+      expect(request).to have_been_made
+    end
+  end
+end

--- a/spec/support/shared_examples/paginated_endpoint.rb
+++ b/spec/support/shared_examples/paginated_endpoint.rb
@@ -3,11 +3,12 @@
 shared_examples_for 'a paginated index' do
   let(:fixture_path) { }
   let(:api_path) { }
+  let(:parameters) { {} }
 
   it 'returns a paginated resource' do
     fixture = api_fixture(fixture_path)
     stub_do_api(api_path, :get).to_return(body: fixture)
-    response = resource.all(page: 1, per_page: 1)
+    response = resource.all({page: 1, per_page: 1}.merge(parameters))
     expect(response).to be_kind_of(DropletKit::PaginatedResource)
   end
 end


### PR DESCRIPTION
Adds support for upcoming floating ip endpoints in API v2.

- [x] Depends on  a75f8e7 in https://github.com/digitalocean/droplet_kit/pull/67 to fix unrelated spec failures.

cc @nanzhong 