### PR TITLE
Add floating_ip_limit to AccountMapping

### DIFF
--- a/lib/droplet_kit/mappings/account_mapping.rb
+++ b/lib/droplet_kit/mappings/account_mapping.rb
@@ -8,6 +8,7 @@ module DropletKit
 
       scoped :read do
         property :droplet_limit
+        property :floating_ip_limit
         property :email
         property :uuid
         property :email_verified

--- a/lib/droplet_kit/models/account.rb
+++ b/lib/droplet_kit/models/account.rb
@@ -1,6 +1,7 @@
 module DropletKit
   class Account < BaseModel
     attribute :droplet_limit
+    attribute :floating_ip_limit
     attribute :email
     attribute :uuid
     attribute :email_verified

--- a/spec/lib/droplet_kit/resources/account_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/account_resource_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe DropletKit::AccountResource do
       expect(account_info).to be_kind_of(DropletKit::Account)
 
       expect(account_info.droplet_limit).to eq(parsed['account']['droplet_limit'])
+      expect(account_info.floating_ip_limit).to eq(parsed['account']['floating_ip_limit'])
       expect(account_info.email).to eq(parsed['account']['email'])
       expect(account_info.uuid).to eq(parsed['account']['uuid'])
       expect(account_info.email_verified).to eq(parsed['account']['email_verified'])


### PR DESCRIPTION
Updates AccountMapping to include the `floating_ip_limit` key now sent back by the `/v2/account` endpoint.