### PR TITLE
Multiple Droplet create support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 cache: bundler
 
+before_install:
+  - gem update bundler
+
 rvm:
   - "2.0.0"
   - "2.1.5"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Actions supported:
 * `client.droplets.all()`
 * `client.droplets.find(id: 'id')`
 * `client.droplets.create(droplet)`
+* `client.droplets.create_multiple(droplet)`
 * `client.droplets.delete(id: 'id')`
 * `client.droplets.kernels(id: 'id')`
 * `client.droplets.snapshots(id: 'id')`

--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", '> 3.0', '< 5.0.0'
   spec.add_dependency "faraday", '~> 0.9.1'
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 1.11.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0.0"
   spec.add_development_dependency "pry"

--- a/lib/droplet_kit/mappings/droplet_mapping.rb
+++ b/lib/droplet_kit/mappings/droplet_mapping.rb
@@ -26,7 +26,8 @@ module DropletKit
       property :kernel, scopes: [:read], include: KernelMapping
 
       # Create properties arent quite the same
-      property :name, scopes: [:create]
+      property :name, scopes: [:create]  # "Regular" create
+      property :names, scopes: [:create] # Multiple create
       property :region, scopes: [:create]
       property :size, scopes: [:create]
       property :image, scopes: [:create]

--- a/lib/droplet_kit/models/droplet.rb
+++ b/lib/droplet_kit/models/droplet.rb
@@ -7,6 +7,7 @@ module DropletKit
     end
 
     # Used for creates
+    attribute :names
     attribute :ssh_keys
     attribute :backups
     attribute :size

--- a/lib/droplet_kit/resources/droplet_resource.rb
+++ b/lib/droplet_kit/resources/droplet_resource.rb
@@ -18,6 +18,12 @@ module DropletKit
         handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
       end
 
+      action :create_multiple, 'POST /v2/droplets' do
+        body { |object| DropletMapping.representation_for(:create, object) }
+        handler(202) { |response| DropletMapping.extract_collection(response.body, :read) }
+        handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
+      end
+
       action :delete, 'DELETE /v2/droplets/:id' do
         handler(204) { |response| true }
       end

--- a/lib/droplet_kit/version.rb
+++ b/lib/droplet_kit/version.rb
@@ -1,3 +1,3 @@
 module DropletKit
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end

--- a/spec/fixtures/droplets/create_multiple.json
+++ b/spec/fixtures/droplets/create_multiple.json
@@ -1,0 +1,160 @@
+{
+  "droplets": [
+    {
+      "id": 19,
+      "name": "test-01.example.com",
+      "memory": 1024,
+      "vcpus": 2,
+      "disk": 20,
+      "region": {
+        "slug": "nyc1",
+        "name": "New York",
+        "sizes": [
+          "1024mb",
+          "512mb"
+        ],
+        "available": true,
+        "features": [
+          "virtio",
+          "private_networking",
+          "backups",
+          "ipv6"
+        ]
+      },
+      "image": {
+        "id": 119192817,
+        "name": "Ubuntu 13.04",
+        "distribution": "ubuntu",
+        "slug": "ubuntu1304",
+        "public": true,
+        "regions": [
+          "nyc1"
+        ],
+        "created_at": "2014-07-29T14:35:37Z"
+      },
+      "size_slug": "1024mb",
+      "locked": false,
+      "status": "active",
+      "networks": {
+        "v4": [
+          {
+            "ip_address": "10.0.0.19",
+            "netmask": "255.255.0.0",
+            "gateway": "10.0.0.1",
+            "type": "private"
+          },
+          {
+            "ip_address": "127.0.0.19",
+            "netmask": "255.255.255.0",
+            "gateway": "127.0.0.20",
+            "type": "public"
+          }
+        ],
+        "v6": [
+          {
+            "ip_address": "2001::13",
+            "cidr": 124,
+            "gateway": "2400:6180:0000:00D0:0000:0000:0009:7000",
+            "type": "public"
+          }
+        ]
+      },
+      "kernel": {
+        "id": 485432985,
+        "name": "DO-recovery-static-fsck",
+        "version": "3.8.0-25-generic"
+      },
+      "created_at": "2014-07-29T14:35:37Z",
+      "features": [
+        "ipv6"
+      ],
+      "backup_ids": [
+        449676382
+      ],
+      "snapshot_ids": [
+        449676383
+      ],
+      "action_ids": [
+
+      ]
+    },
+    {
+      "id": 20,
+      "name": "test-02.example.com",
+      "memory": 1024,
+      "vcpus": 2,
+      "disk": 20,
+      "region": {
+        "slug": "nyc1",
+        "name": "New York",
+        "sizes": [
+          "1024mb",
+          "512mb"
+        ],
+        "available": true,
+        "features": [
+          "virtio",
+          "private_networking",
+          "backups",
+          "ipv6"
+        ]
+      },
+      "image": {
+        "id": 119192817,
+        "name": "Ubuntu 13.04",
+        "distribution": "ubuntu",
+        "slug": "ubuntu1304",
+        "public": true,
+        "regions": [
+          "nyc1"
+        ],
+        "created_at": "2014-07-29T14:35:37Z"
+      },
+      "size_slug": "1024mb",
+      "locked": false,
+      "status": "active",
+      "networks": {
+        "v4": [
+          {
+            "ip_address": "10.0.0.19",
+            "netmask": "255.255.0.0",
+            "gateway": "10.0.0.1",
+            "type": "private"
+          },
+          {
+            "ip_address": "127.0.0.19",
+            "netmask": "255.255.255.0",
+            "gateway": "127.0.0.20",
+            "type": "public"
+          }
+        ],
+        "v6": [
+          {
+            "ip_address": "2001::13",
+            "cidr": 124,
+            "gateway": "2400:6180:0000:00D0:0000:0000:0009:7000",
+            "type": "public"
+          }
+        ]
+      },
+      "kernel": {
+        "id": 485432985,
+        "name": "DO-recovery-static-fsck",
+        "version": "3.8.0-25-generic"
+      },
+      "created_at": "2014-07-29T14:35:37Z",
+      "features": [
+        "ipv6"
+      ],
+      "backup_ids": [
+        449676382
+      ],
+      "snapshot_ids": [
+        449676383
+      ],
+      "action_ids": [
+
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds `droplets.create_multiple` method for multiple droplet create.

cc @phillbaker @nanzhong 