### PR TITLE
replaced some attr_accessor methods with attr_writer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
 require "bundler/gem_tasks"
 
 load './lib/tasks/resource_doc.rake'
-

--- a/lib/droplet_kit.rb
+++ b/lib/droplet_kit.rb
@@ -74,7 +74,8 @@ module DropletKit
   FailedUpdate = Class.new(DropletKit::Error)
 
   class RateLimitReached < DropletKit::Error
-    attr_accessor :limit, :remaining, :reset_at
+    attr_accessor :reset_at
+    attr_writer :limit, :remaining
 
     def limit
       @limit.to_i if @limit


### PR DESCRIPTION
Replaced some `attr_accessor`s with `attr_writer`s to prevent creating methods that were being overridden anyway.