### PR TITLE
Add generic methods for creating droplet actions by id or tag

### DIFF
--- a/lib/droplet_kit/resources/droplet_action_resource.rb
+++ b/lib/droplet_kit/resources/droplet_action_resource.rb
@@ -6,13 +6,24 @@ module DropletKit
       password_reset enable_ipv6 enable_backups disable_backups
       enable_private_networking)
 
-    BATCH_SUPPORTED_ACTIONS = %w(
+    TAG_ACTIONS = %w(
       enable_backups disable_backups power_cycle power_on power_off shutdown
       enable_private_networking enable_ipv6 snapshot
     )
 
     resources do
       default_handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
+
+      action :action_for_id, 'POST /v2/droplets/:droplet_id/actions' do
+        body { |hash| hash.tap { |h| h.delete(:droplet_id) }.to_json }
+        handler(201, 200) { |response| ActionMapping.extract_single(response.body, :read) }
+      end
+
+      action :action_for_tag, 'POST /v2/droplets/actions' do
+        query_keys :tag
+        body { |hash| hash.to_json }
+        handler(201, 200) { |response| ActionMapping.extract_single(response.body, :read) }
+      end
 
       ACTIONS_WITHOUT_INPUT.each do |action_name|
         action action_name.to_sym, 'POST /v2/droplets/:droplet_id/actions' do
@@ -21,7 +32,7 @@ module DropletKit
         end
       end
 
-      BATCH_SUPPORTED_ACTIONS.each do |action_name|
+      TAG_ACTIONS.each do |action_name|
         action "#{action_name}_for_tag".to_sym, 'POST /v2/droplets/actions' do
           query_keys :tag
           body { |_| { type: action_name }.to_json }

--- a/spec/lib/droplet_kit/resources/droplet_action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_action_resource_spec.rb
@@ -8,11 +8,37 @@ RSpec.describe DropletKit::DropletActionResource do
 
   include_context 'resources'
 
-  ACTIONS_WITHOUT_INPUT = %w(reboot power_cycle shutdown power_off
-    power_on password_reset enable_ipv6 disable_backups enable_backups
-    enable_private_networking upgrade)
+  describe '#action_for_id' do
+    let(:action) { 'event' }
+    let(:path) { "/v2/droplets/#{droplet_id}/actions" }
+    let(:fixture) { api_fixture('droplet_actions/find') }
 
-  ACTIONS_WITHOUT_INPUT.each do |action_name|
+    it 'performs the action' do
+      request = stub_do_api(path, :post).with(
+        body: { type: action, param_1: 1, param_2: 2 }.to_json
+      ).to_return(body: fixture, status: 201)
+
+      resource.action_for_id(droplet_id: droplet_id, type: action, param_1: 1, param_2: 2)
+      expect(request).to have_been_made
+    end
+  end
+
+  describe '#action_for_tag' do
+    let(:action) { 'event' }
+    let(:path) { '/v2/droplets/actions' }
+    let(:fixture) { api_fixture('droplet_actions/find') }
+
+    it 'performs the action' do
+      request = stub_do_api(path, :post).with(
+        body: { tag: 'test-tag', type: action, param_1: 1, param_2: 2 }.to_json
+      ).to_return(body: fixture, status: 201)
+
+      resource.action_for_tag(tag: 'test-tag', type: action, param_1: 1, param_2: 2)
+      expect(request).to have_been_made
+    end
+  end
+
+  described_class::ACTIONS_WITHOUT_INPUT.each do |action_name|
     describe "Action #{action_name}" do
       let(:action) { action_name }
       let(:path) { "/v2/droplets/#{droplet_id}/actions" }
@@ -35,7 +61,7 @@ RSpec.describe DropletKit::DropletActionResource do
     end
   end
 
-  described_class::BATCH_SUPPORTED_ACTIONS.each do |action_name|
+  described_class::TAG_ACTIONS.each do |action_name|
     describe "Batch Action #{action_name}" do
       let(:action) { "#{action_name}_for_tag" }
       let(:path) { "/v2/droplets/actions?tag=testing-1" }


### PR DESCRIPTION
This adds some generic action methods that can be used:
```ruby
client.droplet_actions.action_for_id(droplet_id: 123, type: 'power_off')
client.droplet_actions.action_for_tag(tag: 'testing-1', type: 'power_off')
```

cc @phillbaker 