### PR TITLE
Fix bug with destroy droplet by tag and add tagging to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ client.droplets #=> DropletKit::DropletResource
 Actions supported:
 
 * `client.droplets.all()`
+* `client.droplets.all(tag_name: 'tag_name')`
 * `client.droplets.find(id: 'id')`
 * `client.droplets.create(droplet)`
 * `client.droplets.create_multiple(droplet)`
 * `client.droplets.delete(id: 'id')`
+* `client.droplets.delete_for_tag(tag_name: 'tag_name')`
 * `client.droplets.kernels(id: 'id')`
 * `client.droplets.snapshots(id: 'id')`
 * `client.droplets.backups(id: 'id')`
@@ -94,22 +96,33 @@ Actions supported:
 
 * `client.droplet_actions.reboot(droplet_id: droplet.id)`
 * `client.droplet_actions.power_cycle(droplet_id: droplet.id)`
+* `client.droplet_actions.power_cycle_for_tag(tag: 'tag_name')`
 * `client.droplet_actions.shutdown(droplet_id: droplet.id)`
+* `client.droplet_actions.shutdown_for_tag(tag: 'tag_name')`
 * `client.droplet_actions.power_off(droplet_id: droplet.id)`
+* `client.droplet_actions.power_off_for_tag(tag: 'tag_name')`
 * `client.droplet_actions.power_on(droplet_id: droplet.id)`
+* `client.droplet_actions.power_on_for_tag(tag: 'tag_name')`
 * `client.droplet_actions.password_reset(droplet_id: droplet.id)`
 * `client.droplet_actions.enable_ipv6(droplet_id: droplet.id)`
+* `client.droplet_actions.enable_ipv6_for_tag(tag: 'tag_name')`
 * `client.droplet_actions.enable_backups(droplet_id: droplet.id)`
+* `client.droplet_actions.enable_backups_for_tag(tag: 'tag_name')`
 * `client.droplet_actions.disable_backups(droplet_id: droplet.id)`
+* `client.droplet_actions.disable_backups_for_tag(tag: 'tag_name')`
 * `client.droplet_actions.upgrade(droplet_id: droplet.id)`
 * `client.droplet_actions.enable_private_networking(droplet_id: droplet.id)`
+* `client.droplet_actions.enable_private_networking_for_tag(tag: 'tag_name')`
 * `client.droplet_actions.snapshot(droplet_id: droplet.id, name: 'Snapshot Name')`
+* `client.droplet_actions.snapshot_for_tag(tag: 'tag_name', name: 'Snapshot Name')`
 * `client.droplet_actions.change_kernel(droplet_id: droplet.id, kernel: 'kernel_id')`
 * `client.droplet_actions.rename(droplet_id: droplet.id, name: 'New-Droplet-Name')`
 * `client.droplet_actions.rebuild(droplet_id: droplet.id, image: 'image_id')`
 * `client.droplet_actions.restore(droplet_id: droplet.id, image: 'image_id')`
 * `client.droplet_actions.resize(droplet_id: droplet.id, size: '1gb')`
 * `client.droplet_actions.find(droplet_id: droplet.id, id: action.id)`
+* `client.droplet_actions.action_for_id(droplet_id: droplet.id, type: 'event_name', param: 'value')`
+* `client.droplet_actions.action_for_tag(tag: 'tag_name', type: 'event_name', param: 'value')`
 
 ## Domain resource
 

--- a/lib/droplet_kit/resources/droplet_resource.rb
+++ b/lib/droplet_kit/resources/droplet_resource.rb
@@ -4,7 +4,7 @@ module DropletKit
 
     resources do
       action :all, 'GET /v2/droplets' do
-        query_keys :per_page, :page
+        query_keys :per_page, :page, :tag_name
         handler(200) { |response| DropletMapping.extract_collection(response.body, :read) }
       end
 
@@ -50,7 +50,7 @@ module DropletKit
 
       action :delete_for_tag, 'DELETE /v2/droplets' do
         verb :delete
-        query_keys :tag
+        query_keys :tag_name
         handler(204) { |_| true }
       end
     end

--- a/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
@@ -327,8 +327,8 @@ RSpec.describe DropletKit::DropletResource do
 
   describe '#delete_tagged' do
     it 'sends a delete request for the tagged droplet' do
-      request = stub_do_api('/v2/droplets?tag=testing-1', :delete)
-      resource.delete_for_tag(tag: 'testing-1')
+      request = stub_do_api('/v2/droplets?tag_name=testing-1', :delete)
+      resource.delete_for_tag(tag_name: 'testing-1')
 
       expect(request).to have_been_made
     end


### PR DESCRIPTION
Destroying droplets by tag was using the incorrect query param (this also reveals an inconsistency in the api since both `tag_name` and `tag` are used). This PR fixes this.

This PR also adds the tagging methods to the readme.

Depends on https://github.com/digitalocean/droplet_kit/pull/82/files for the generic droplet action methods.

cc @phillbaker 