### PR TITLE
Pass tag_name instead of tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,25 +96,25 @@ Actions supported:
 
 * `client.droplet_actions.reboot(droplet_id: droplet.id)`
 * `client.droplet_actions.power_cycle(droplet_id: droplet.id)`
-* `client.droplet_actions.power_cycle_for_tag(tag: 'tag_name')`
+* `client.droplet_actions.power_cycle_for_tag(tag_name: 'tag_name')`
 * `client.droplet_actions.shutdown(droplet_id: droplet.id)`
-* `client.droplet_actions.shutdown_for_tag(tag: 'tag_name')`
+* `client.droplet_actions.shutdown_for_tag(tag_name: 'tag_name')`
 * `client.droplet_actions.power_off(droplet_id: droplet.id)`
-* `client.droplet_actions.power_off_for_tag(tag: 'tag_name')`
+* `client.droplet_actions.power_off_for_tag(tag_name: 'tag_name')`
 * `client.droplet_actions.power_on(droplet_id: droplet.id)`
-* `client.droplet_actions.power_on_for_tag(tag: 'tag_name')`
+* `client.droplet_actions.power_on_for_tag(tag_name: 'tag_name')`
 * `client.droplet_actions.password_reset(droplet_id: droplet.id)`
 * `client.droplet_actions.enable_ipv6(droplet_id: droplet.id)`
-* `client.droplet_actions.enable_ipv6_for_tag(tag: 'tag_name')`
+* `client.droplet_actions.enable_ipv6_for_tag(tag_name: 'tag_name')`
 * `client.droplet_actions.enable_backups(droplet_id: droplet.id)`
-* `client.droplet_actions.enable_backups_for_tag(tag: 'tag_name')`
+* `client.droplet_actions.enable_backups_for_tag(tag_name: 'tag_name')`
 * `client.droplet_actions.disable_backups(droplet_id: droplet.id)`
-* `client.droplet_actions.disable_backups_for_tag(tag: 'tag_name')`
+* `client.droplet_actions.disable_backups_for_tag(tag_name: 'tag_name')`
 * `client.droplet_actions.upgrade(droplet_id: droplet.id)`
 * `client.droplet_actions.enable_private_networking(droplet_id: droplet.id)`
-* `client.droplet_actions.enable_private_networking_for_tag(tag: 'tag_name')`
+* `client.droplet_actions.enable_private_networking_for_tag(tag_name: 'tag_name')`
 * `client.droplet_actions.snapshot(droplet_id: droplet.id, name: 'Snapshot Name')`
-* `client.droplet_actions.snapshot_for_tag(tag: 'tag_name', name: 'Snapshot Name')`
+* `client.droplet_actions.snapshot_for_tag(tag_name: 'tag_name', name: 'Snapshot Name')`
 * `client.droplet_actions.change_kernel(droplet_id: droplet.id, kernel: 'kernel_id')`
 * `client.droplet_actions.rename(droplet_id: droplet.id, name: 'New-Droplet-Name')`
 * `client.droplet_actions.rebuild(droplet_id: droplet.id, image: 'image_id')`
@@ -122,7 +122,7 @@ Actions supported:
 * `client.droplet_actions.resize(droplet_id: droplet.id, size: '1gb')`
 * `client.droplet_actions.find(droplet_id: droplet.id, id: action.id)`
 * `client.droplet_actions.action_for_id(droplet_id: droplet.id, type: 'event_name', param: 'value')`
-* `client.droplet_actions.action_for_tag(tag: 'tag_name', type: 'event_name', param: 'value')`
+* `client.droplet_actions.action_for_tag(tag_name: 'tag_name', type: 'event_name', param: 'value')`
 
 ## Domain resource
 

--- a/lib/droplet_kit/resources/droplet_action_resource.rb
+++ b/lib/droplet_kit/resources/droplet_action_resource.rb
@@ -20,7 +20,7 @@ module DropletKit
       end
 
       action :action_for_tag, 'POST /v2/droplets/actions' do
-        query_keys :tag
+        query_keys :tag_name
         body { |hash| hash.to_json }
         handler(201, 200) { |response| ActionMapping.extract_single(response.body, :read) }
       end
@@ -34,7 +34,7 @@ module DropletKit
 
       TAG_ACTIONS.each do |action_name|
         action "#{action_name}_for_tag".to_sym, 'POST /v2/droplets/actions' do
-          query_keys :tag
+          query_keys :tag_name
           body { |_| { type: action_name }.to_json }
           handler(201, 200) { |response| ActionMapping.extract_collection(response.body, :read) }
         end

--- a/spec/lib/droplet_kit/resources/droplet_action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_action_resource_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe DropletKit::DropletActionResource do
 
     it 'performs the action' do
       request = stub_do_api(path, :post).with(
-        body: { tag: 'test-tag', type: action, param_1: 1, param_2: 2 }.to_json
+        body: { tag_name: 'test-tag', type: action, param_1: 1, param_2: 2 }.to_json
       ).to_return(body: fixture, status: 201)
 
-      resource.action_for_tag(tag: 'test-tag', type: action, param_1: 1, param_2: 2)
+      resource.action_for_tag(tag_name: 'test-tag', type: action, param_1: 1, param_2: 2)
       expect(request).to have_been_made
     end
   end
@@ -64,7 +64,7 @@ RSpec.describe DropletKit::DropletActionResource do
   described_class::TAG_ACTIONS.each do |action_name|
     describe "Batch Action #{action_name}" do
       let(:action) { "#{action_name}_for_tag" }
-      let(:path) { "/v2/droplets/actions?tag=testing-1" }
+      let(:path) { "/v2/droplets/actions?tag_name=testing-1" }
       let(:fixture) do
         single_action = DropletKit::ActionMapping.extract_single(api_fixture("droplet_actions/#{action_name}"), :read)
 
@@ -76,7 +76,7 @@ RSpec.describe DropletKit::DropletActionResource do
           body: { type: action_name }.to_json
         ).to_return(body: fixture, status: 201)
 
-        returned_actions = resource.send(action, tag: 'testing-1')
+        returned_actions = resource.send(action, tag_name: 'testing-1')
 
         expect(request).to have_been_made
         expect(returned_actions.first.type).to eq(action_name)


### PR DESCRIPTION
[The API Docs](https://developers.digitalocean.com/documentation/v2/#acting-on-tagged-droplets)
seem to suggest that tag_name should be used instead of tag.

When testing against the actual API, tag failed where tag_name succeeded.

I have updated the DropletActionResource and its specs to use tag_name.

Also updated the examples in the README.

This PR might also address [#91]
