### PR TITLE
Fix `DropletKit::Client` to allow it to call `Volume` resources

### DIFF
--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -32,7 +32,8 @@ module DropletKit
         floating_ips: FloatingIpResource,
         floating_ip_actions: FloatingIpActionResource,
         tags: TagResource,
-        volumes: VolumeResource
+        volumes: VolumeResource,
+        volume_actions: VolumeActionResource
       }
     end
 

--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -31,7 +31,8 @@ module DropletKit
         account: AccountResource,
         floating_ips: FloatingIpResource,
         floating_ip_actions: FloatingIpActionResource,
-        tags: TagResource
+        tags: TagResource,
+        volumes: VolumeResource
       }
     end
 

--- a/lib/droplet_kit/version.rb
+++ b/lib/droplet_kit/version.rb
@@ -1,3 +1,3 @@
 module DropletKit
-  VERSION = "1.4.2"
+  VERSION = "1.4.3"
 end


### PR DESCRIPTION
When the gem was updated to allow for the use of the block storage API, it was forgotten to add the `VolumeResource` to the `client.rb` file. This pull request addresses that and bumps the gem version, making it ready for release.