### PR TITLE
Beta: Add snapshot resource and volume snapshot endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,10 @@ Actions supported:
 * `client.volumes.all()`
 * `client.volumes.find(id: 'id')`
 * `client.volumes.create(volume)`
+* `client.volumes.snapshots(id: 'id')`
+* `client.volumes.create_snapshot(id: 'id', name: 'snapshot-name')`
 * `client.volumes.delete(id: 'id')`
+
 
 ## Volume Action resource
 
@@ -294,6 +297,17 @@ Actions supported:
 * `client.volume_actions.attach(volume_id: volume.id, droplet_id: droplet.id, region: droplet.region.slug)`
 * `client.volume_actions.detach(volume_id: volume.id, droplet_id: droplet.id, region: droplet.region.slug)`
 * `client.volume_actions.resize(volume_id: volume.id, size_gigabytes: 123, region: droplet.region.slug)`
+
+## Volume resource
+
+    client = DropletKit::Client.new(access_token: 'TOKEN')
+    client.snapshots #=> DropletKit::SnapshotResource
+
+Actions supported:
+
+* `client.snapshots.all(resource_type: 'droplet')`
+* `client.snapshots.find(id: 'id')`
+* `client.snapshots.delete(id: 'id')`
 
 ## Contributing
 

--- a/lib/droplet_kit.rb
+++ b/lib/droplet_kit.rb
@@ -49,6 +49,7 @@ module DropletKit
   autoload :TagResource, 'droplet_kit/resources/tag_resource'
   autoload :VolumeResource, 'droplet_kit/resources/volume_resource'
   autoload :VolumeActionResource, 'droplet_kit/resources/volume_action_resource'
+  autoload :SnapshotResource, 'droplet_kit/resources/snapshot_resource'
 
   # JSON Maps
   autoload :DropletMapping, 'droplet_kit/mappings/droplet_mapping'

--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -28,6 +28,7 @@ module DropletKit
         regions: RegionResource,
         sizes: SizeResource,
         ssh_keys: SSHKeyResource,
+        snapshots: SnapshotResource,
         account: AccountResource,
         floating_ips: FloatingIpResource,
         floating_ip_actions: FloatingIpActionResource,

--- a/lib/droplet_kit/mappings/image_mapping.rb
+++ b/lib/droplet_kit/mappings/image_mapping.rb
@@ -5,14 +5,15 @@ module DropletKit
     kartograph do
       mapping Image
       root_key plural: 'images', singular: 'image', scopes: [:read]
+      root_key plural: 'snapshots', singular: 'snapshot', scopes: [:read_snapshot]
 
-      property :id, scopes: [:read]
-      property :name, scopes: [:read, :update]
-      property :distribution, scopes: [:read]
-      property :slug, scopes: [:read]
-      property :public, scopes: [:read]
-      property :regions, scopes: [:read]
-      property :type, scopes: [:read]
+      property :id, scopes: [:read, :read_snapshot]
+      property :name, scopes: [:read, :update, :read_snapshot]
+      property :distribution, scopes: [:read, :read_snapshot]
+      property :slug, scopes: [:read, :read_snapshot]
+      property :public, scopes: [:read, :read_snapshot]
+      property :regions, scopes: [:read, :read_snapshot]
+      property :type, scopes: [:read, :read_snapshot]
     end
   end
 end

--- a/lib/droplet_kit/mappings/snapshot_mapping.rb
+++ b/lib/droplet_kit/mappings/snapshot_mapping.rb
@@ -8,12 +8,12 @@ module DropletKit
 
       property :id, scopes: [:read]
       property :name, scopes: [:read]
-      property :distribution, scopes: [:read]
-      property :slug, scopes: [:read]
-      property :public, scopes: [:read]
       property :regions, scopes: [:read]
-      property :action_ids, scopes: [:read]
       property :created_at, scopes: [:read]
+      property :resource_id, scopes: [:read]
+      property :resource_type, scopes: [:read]
+      property :min_disk_size, scopes: [:read]
+      property :size_gigabytes, scopes: [:read]
     end
   end
 end

--- a/lib/droplet_kit/mappings/volume_mapping.rb
+++ b/lib/droplet_kit/mappings/volume_mapping.rb
@@ -15,6 +15,7 @@ module DropletKit
       property :created_at, scopes: [:read]
 
       property :region, scopes: [:create]
+      property :snapshot_id, scopes: [:create]
     end
   end
 end

--- a/lib/droplet_kit/models/snapshot.rb
+++ b/lib/droplet_kit/models/snapshot.rb
@@ -2,11 +2,11 @@ module DropletKit
   class Snapshot < BaseModel
     attribute :id
     attribute :name
-    attribute :distribution
-    attribute :slug
-    attribute :public
     attribute :regions
-    attribute :action_ids
     attribute :created_at
+    attribute :resource_id
+    attribute :resource_type
+    attribute :min_disk_size
+    attribute :size_gigabytes
   end
 end

--- a/lib/droplet_kit/models/volume.rb
+++ b/lib/droplet_kit/models/volume.rb
@@ -7,5 +7,8 @@ module DropletKit
     attribute :description
     attribute :size_gigabytes
     attribute :created_at
+
+    # Used for creates
+    attribute :snapshot_id
   end
 end

--- a/lib/droplet_kit/resources/droplet_resource.rb
+++ b/lib/droplet_kit/resources/droplet_resource.rb
@@ -35,7 +35,7 @@ module DropletKit
 
       action :snapshots, 'GET /v2/droplets/:id/snapshots' do
         query_keys :per_page, :page
-        handler(200) { |response| SnapshotMapping.extract_collection(response.body, :read) }
+        handler(200) { |response| ImageMapping.extract_collection(response.body, :read_snapshot) }
       end
 
       action :backups, 'GET /v2/droplets/:id/backups' do

--- a/lib/droplet_kit/resources/snapshot_resource.rb
+++ b/lib/droplet_kit/resources/snapshot_resource.rb
@@ -1,0 +1,24 @@
+module DropletKit
+  class SnapshotResource < ResourceKit::Resource
+    include ErrorHandlingResourcable
+
+    resources do
+      action :all, 'GET /v2/snapshots' do
+        query_keys :page, :per_page, :resource_type
+        handler(200) { |response| SnapshotMapping.extract_collection(response.body, :read) }
+      end
+
+      action :find, 'GET /v2/snapshots/:id' do
+        handler(200) { |response| SnapshotMapping.extract_single(response.body, :read) }
+      end
+
+      action :delete, 'DELETE /v2/snapshots/:id' do
+        handler(204) { |_| true }
+      end
+    end
+
+    def all(*args)
+      PaginatedResource.new(action(:all), self, *args)
+    end
+  end
+end

--- a/lib/droplet_kit/resources/volume_resource.rb
+++ b/lib/droplet_kit/resources/volume_resource.rb
@@ -21,10 +21,25 @@ module DropletKit
       action :delete, 'DELETE /v2/volumes/:id' do
         handler(204) { |response| true }
       end
+
+      action :snapshots, 'GET /v2/volumes/:id/snapshots' do
+        query_keys :per_page, :page
+        handler(200) { |response| SnapshotMapping.extract_collection(response.body, :read) }
+      end
+
+      action :create_snapshot, 'POST /v2/volumes/:id/snapshots' do
+        body { |hash| { name: hash[:name] }.to_json }
+        handler(201) { |response| SnapshotMapping.extract_single(response.body, :read) }
+        handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
+      end
     end
 
     def all(*args)
       PaginatedResource.new(action(:all), self, *args)
+    end
+
+    def snapshots(*args)
+      PaginatedResource.new(action(:snapshots), self, *args)
     end
   end
 end

--- a/spec/fixtures/snapshots/all.json
+++ b/spec/fixtures/snapshots/all.json
@@ -1,0 +1,32 @@
+{
+  "snapshots": [
+    {
+      "id": "119192817",
+      "name": "Ubuntu 13.04",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2014-07-29T14:35:40Z",
+      "resource_type": "droplet",
+      "resource_id": "123",
+      "resource_type": "droplet",
+      "min_disk_size": 10,
+      "size_gigabytes": 0.4
+    },
+    {
+      "id": "7724db7c-e098-11e5-b522-000f53304e51",
+      "name": "Ubuntu Foo",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2014-07-29T14:35:40Z",
+      "resource_type": "volume",
+      "resource_id": "7724db7c-e098-11e5-b522-000f53304e51",
+      "min_disk_size": 10,
+      "size_gigabytes": 0.4
+    }
+  ],
+  "meta": {
+    "total": 2
+  }
+}

--- a/spec/fixtures/snapshots/find.json
+++ b/spec/fixtures/snapshots/find.json
@@ -1,0 +1,14 @@
+{
+  "snapshot": {
+    "id": "7724db7c-e098-11e5-b522-000f53304e51",
+    "name": "Ubuntu Foo",
+    "regions": [
+      "nyc1"
+    ],
+    "created_at": "2014-07-29T14:35:40Z",
+    "resource_type": "volume",
+    "resource_id": "7724db7c-e098-11e5-b522-000f53304e51",
+    "min_disk_size": 10,
+    "size_gigabytes": 0.4
+  }
+}

--- a/spec/fixtures/snapshots/resource_type.json
+++ b/spec/fixtures/snapshots/resource_type.json
@@ -1,0 +1,20 @@
+{
+  "snapshots": [
+    {
+      "id": "119192817",
+      "name": "Ubuntu 13.04",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2014-07-29T14:35:40Z",
+      "resource_type": "droplet",
+      "resource_id": "123",
+      "resource_type": "droplet",
+      "min_disk_size": 10,
+      "size_gigabytes": 0.4
+    }
+  ],
+  "meta": {
+    "total": 1
+  }
+}

--- a/spec/fixtures/volumes/create_snapshot.json
+++ b/spec/fixtures/volumes/create_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "snapshot": {
+    "id": "7724db7c-e098-11e5-b522-000f53304e51",
+    "name": "Ubuntu Foo",
+    "regions": [
+      "nyc1"
+    ],
+    "created_at": "2014-07-29T14:35:40Z",
+    "resource_type": "volume",
+    "resource_id": "7724db7c-e098-11e5-b522-000f53304e51",
+    "min_disk_size": 10,
+    "size_gigabytes": 0.4
+  }
+}

--- a/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
@@ -244,18 +244,17 @@ RSpec.describe DropletKit::DropletResource do
   end
 
   describe '#snapshots' do
-    it 'returns a list of kernels for a droplet' do
+    it 'returns a list of image snapshots for a droplet' do
       stub_do_api('/v2/droplets/1066/snapshots', :get).to_return(body: api_fixture('droplets/list_snapshots'))
       snapshots = resource.snapshots(id: 1066).take(20)
 
-      expect(snapshots).to all(be_kind_of(DropletKit::Snapshot))
+      expect(snapshots).to all(be_kind_of(DropletKit::Image))
       expect(snapshots[0].id).to eq(449676387)
       expect(snapshots[0].name).to eq("Ubuntu 13.04")
       expect(snapshots[0].distribution).to eq("ubuntu")
       expect(snapshots[0].slug).to eq(nil)
       expect(snapshots[0].public).to eq(false)
       expect(snapshots[0].regions).to eq(["nyc1"])
-      expect(snapshots[0].created_at).to eq("2014-07-29T14:35:38Z")
     end
 
     it 'returns a paginated resource' do

--- a/spec/lib/droplet_kit/resources/snapshot_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/snapshot_resource_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe DropletKit::SnapshotResource do
+  subject(:resource) { described_class.new(connection: connection) }
+  include_context 'resources'
+
+  describe '#all' do
+    it 'returns all of the snapshots' do
+      snapshots_json = api_fixture('snapshots/all')
+      stub_do_api('/v2/snapshots', :get).to_return(body: snapshots_json)
+      expected_snapshots = DropletKit::SnapshotMapping.extract_collection(snapshots_json, :read)
+
+      expect(resource.all).to eq(expected_snapshots)
+    end
+
+    it 'returns snapshots of a type' do
+      snapshots_json = api_fixture('snapshots/resource_type')
+      stub_do_api('/v2/snapshots', :get)
+        .with(query: hash_including({ resource_type: 'droplet' }))
+        .to_return(body: snapshots_json)
+      expected_snapshots = DropletKit::SnapshotMapping.extract_collection(snapshots_json, :read)
+
+      expect(resource.all(resource_type: :droplet)).to eq(expected_snapshots)
+    end
+
+    it_behaves_like 'a paginated index' do
+      let(:fixture_path) { 'snapshots/all' }
+      let(:api_path) { '/v2/snapshots' }
+    end
+  end
+
+  describe '#find' do
+    it 'returns a singular snapshot' do
+      stub_do_api('/v2/snapshots/7724db7c-e098-11e5-b522-000f53304e51', :get).to_return(body: api_fixture('snapshots/find'))
+      snapshot = resource.find(id: "7724db7c-e098-11e5-b522-000f53304e51")
+
+      expect(snapshot.id).to eq("7724db7c-e098-11e5-b522-000f53304e51")
+      expect(snapshot.name).to eq("Ubuntu Foo")
+      expect(snapshot.regions).to eq(["nyc1"])
+      expect(snapshot.resource_type).to eq("volume")
+      expect(snapshot.resource_id).to eq("7724db7c-e098-11e5-b522-000f53304e51")
+      expect(snapshot.min_disk_size).to eq(10)
+      expect(snapshot.size_gigabytes).to eq(0.4)
+    end
+
+    it_behaves_like 'resource that handles common errors' do
+      let(:path) { '/v2/snapshots/123' }
+      let(:method) { :get }
+      let(:action) { :find }
+      let(:arguments) { { id: 123 } }
+    end
+  end
+
+  describe '#delete' do
+    it 'deletes an snapshot' do
+      request = stub_do_api('/v2/snapshots/146', :delete).to_return(body: '', status: 204)
+      resource.delete(id: 146)
+      expect(request).to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
This redefines DropletKit::Snapshot to be different than DropletKit::Image.

We should do a major version bump for this.

cc @mikejholly @mjsteger 