### PR TITLE
Changes connection method to instance variable

### DIFF
--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -11,7 +11,7 @@ module DropletKit
     end
 
     def connection
-      Faraday.new(connection_options) do |req|
+      @faraday ||= Faraday.new connection_options do |req|
         req.adapter :net_http
       end
     end

--- a/spec/lib/droplet_kit/client_spec.rb
+++ b/spec/lib/droplet_kit/client_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe DropletKit::Client do
   end
 
   describe '#connection' do
+    module AcmeApp
+      class CustomLogger < Faraday::Middleware
+      end
+    end
+
     it 'populates the authorization header correctly' do
       expect(client.connection.headers['Authorization']).to eq("Bearer #{client.access_token}")
     end
@@ -33,5 +38,12 @@ RSpec.describe DropletKit::Client do
     it 'sets the content type' do
       expect(client.connection.headers['Content-Type']).to eq("application/json")
     end
+
+    it 'allows access to faraday instance' do
+      client.connection.use AcmeApp::CustomLogger
+      expect(client.connection.builder.handlers).to include(AcmeApp::CustomLogger)
+    end
   end
+
 end
+


### PR DESCRIPTION
Closes #102 

* This allows instance variable reference to the Faraday connection.
* For example, a user can use this to allow loading of middleware with DropletKit, such as a logging middleware for showing debug output of requests to the DigitalOcean API:

```
>> client = DropletKit::Client.new(access_token: ‘abc123’)
=> #<DropletKit::Client:0x007fdb4402fdb0 @access_token="abc123">
>> client.connection.use AcmeApp::CustomLogger
>> client.droplets.all.first
I, [2016-10-10T01:05:54.431118 #1382]  INFO -- : Started GET request to: https://api.digitalocean.com/v2/droplets?page=1&per_page=20
D, [2016-10-10T01:05:54.432920 #1382] DEBUG -- : Request Headers:
----------------
Content-Type  : application/json
```

I wrote a basic spec for my personal use-case, but there might be a better way of testing it 😄 