### PR TITLE
Add Certificate and LoadBalancer resources.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tmp
 *.o
 *.a
 mkmf.log
+vendor

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ droplet = client.droplets.find(id: 123)
 
 # All Resources and actions.
 
+## Certificate resource
+
+```ruby
+client = DropletKit::Client.new(access_token: 'TOKEN')
+client.certificates #=> DropletKit::CertificateResource
+```
+
+Actions supported:
+
+* `client.certificates.find(id: 'id')`
+* `client.certificates.all()`
+* `client.certificates.create(certificate)`
+* `client.certificates.delete(id: 'id')`
+
+
 ## Droplet resource
 
 ```ruby
@@ -187,6 +202,25 @@ Image Actions Supported:
 * `client.image_actions.all(image_id: 123)`
 * `client.image_actions.find(image_id: 123, id: 123455)`
 * `client.image_actions.transfer(image_id: 123, region: 'nyc3')`
+
+
+## Load balancer resource
+```ruby
+client = DropletKit::Client.new(access_token: 'TOKEN')
+client.load_balancers #=> DropletKit::LoadBalancerResource
+```
+
+Actions supported:
+
+* `client.load_balancers.find(id: 'id')`
+* `client.load_balancers.all()`
+* `client.load_balancers.create(load_balancer)`
+* `client.load_balancers.update(load_balancer, id: 'id')`
+* `client.load_balancers.delete(id: 'id')`
+* `client.load_balancers.add_droplets([droplet.id], id: 'id')`
+* `client.load_balancers.remove_droplets([droplet.id], id: 'id')`
+* `client.load_balancers.add_forwarding_rules([forwarding_rule], id: 'id')`
+* `client.load_balancers.remove_forwarding_rules([forwarding_rule], id: 'id')`
 
 
 ## Region resource

--- a/lib/droplet_kit.rb
+++ b/lib/droplet_kit.rb
@@ -28,6 +28,10 @@ module DropletKit
   autoload :TaggedResources, 'droplet_kit/models/tagged_resources'
   autoload :TaggedDropletsResources, 'droplet_kit/models/tagged_droplets_resources'
   autoload :Volume, 'droplet_kit/models/volume'
+  autoload :LoadBalancer, 'droplet_kit/models/load_balancer'
+  autoload :StickySession, 'droplet_kit/models/sticky_session'
+  autoload :HealthCheck, 'droplet_kit/models/health_check'
+  autoload :ForwardingRule, 'droplet_kit/models/forwarding_rule'
 
   # Resources
   autoload :DropletResource, 'droplet_kit/resources/droplet_resource'
@@ -48,6 +52,7 @@ module DropletKit
   autoload :VolumeResource, 'droplet_kit/resources/volume_resource'
   autoload :VolumeActionResource, 'droplet_kit/resources/volume_action_resource'
   autoload :SnapshotResource, 'droplet_kit/resources/snapshot_resource'
+  autoload :LoadBalancerResource, 'droplet_kit/resources/load_balancer_resource'
 
   # JSON Maps
   autoload :DropletMapping, 'droplet_kit/mappings/droplet_mapping'
@@ -71,6 +76,10 @@ module DropletKit
   autoload :TaggedResourcesMapping, 'droplet_kit/mappings/tagged_resources_mapping'
   autoload :TaggedDropletsResourcesMapping, 'droplet_kit/mappings/tagged_droplets_resources_mapping'
   autoload :VolumeMapping, 'droplet_kit/mappings/volume_mapping'
+  autoload :LoadBalancerMapping, 'droplet_kit/mappings/load_balancer_mapping'
+  autoload :StickySessionMapping, 'droplet_kit/mappings/sticky_session_mapping'
+  autoload :HealthCheckMapping, 'droplet_kit/mappings/health_check_mapping'
+  autoload :ForwardingRuleMapping, 'droplet_kit/mappings/forwarding_rule_mapping'
 
   # Utils
   autoload :PaginatedResource, 'droplet_kit/paginated_resource'

--- a/lib/droplet_kit.rb
+++ b/lib/droplet_kit.rb
@@ -32,6 +32,7 @@ module DropletKit
   autoload :StickySession, 'droplet_kit/models/sticky_session'
   autoload :HealthCheck, 'droplet_kit/models/health_check'
   autoload :ForwardingRule, 'droplet_kit/models/forwarding_rule'
+  autoload :Certificate, 'droplet_kit/models/certificate'
 
   # Resources
   autoload :DropletResource, 'droplet_kit/resources/droplet_resource'
@@ -53,6 +54,7 @@ module DropletKit
   autoload :VolumeActionResource, 'droplet_kit/resources/volume_action_resource'
   autoload :SnapshotResource, 'droplet_kit/resources/snapshot_resource'
   autoload :LoadBalancerResource, 'droplet_kit/resources/load_balancer_resource'
+  autoload :CertificateResource, 'droplet_kit/resources/certificate_resource'
 
   # JSON Maps
   autoload :DropletMapping, 'droplet_kit/mappings/droplet_mapping'
@@ -80,6 +82,7 @@ module DropletKit
   autoload :StickySessionMapping, 'droplet_kit/mappings/sticky_session_mapping'
   autoload :HealthCheckMapping, 'droplet_kit/mappings/health_check_mapping'
   autoload :ForwardingRuleMapping, 'droplet_kit/mappings/forwarding_rule_mapping'
+  autoload :CertificateMapping, 'droplet_kit/mappings/certificate_mapping'
 
   # Utils
   autoload :PaginatedResource, 'droplet_kit/paginated_resource'

--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -19,6 +19,7 @@ module DropletKit
     def self.resources
       {
         actions: ActionResource,
+        certificates: CertificateResource,
         droplets: DropletResource,
         domains: DomainResource,
         domain_records: DomainRecordResource,

--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -25,6 +25,7 @@ module DropletKit
         droplet_actions: DropletActionResource,
         images: ImageResource,
         image_actions: ImageActionResource,
+        load_balancers: LoadBalancerResource,
         regions: RegionResource,
         sizes: SizeResource,
         ssh_keys: SSHKeyResource,

--- a/lib/droplet_kit/mappings/certificate_mapping.rb
+++ b/lib/droplet_kit/mappings/certificate_mapping.rb
@@ -1,0 +1,25 @@
+module DropletKit
+  class CertificateMapping
+    include Kartograph::DSL
+
+    kartograph do
+      mapping Certificate
+      root_key singular: 'certificate', plural: 'certificates', scopes: [:read]
+
+      scoped :read do
+        property :id
+        property :name
+        property :not_after
+        property :sha1_fingerprint
+        property :created_at
+      end
+
+      scoped :create do
+        property :name
+        property :private_key
+        property :leaf_certificate
+        property :certificate_chain
+      end
+    end
+  end
+end

--- a/lib/droplet_kit/mappings/forwarding_rule_mapping.rb
+++ b/lib/droplet_kit/mappings/forwarding_rule_mapping.rb
@@ -1,0 +1,19 @@
+module DropletKit
+  class ForwardingRuleMapping
+    include Kartograph::DSL
+
+    kartograph do
+      root_key plural: 'forwarding_rules', scopes: [:create, :update]
+      mapping ForwardingRule
+
+      scoped :read, :create, :update do
+        property :entry_protocol
+        property :entry_port
+        property :target_protocol
+        property :target_port
+        property :certificate_id
+        property :tls_passthrough
+      end
+    end
+  end
+end

--- a/lib/droplet_kit/mappings/health_check_mapping.rb
+++ b/lib/droplet_kit/mappings/health_check_mapping.rb
@@ -1,0 +1,19 @@
+module DropletKit
+  class HealthCheckMapping
+    include Kartograph::DSL
+
+    kartograph do
+      mapping HealthCheck
+
+      scoped :read, :create, :update do
+        property :protocol
+        property :port
+        property :path
+        property :check_interval_seconds
+        property :response_timeout_seconds
+        property :healthy_threshold
+        property :unhealthy_threshold
+      end
+    end
+  end
+end

--- a/lib/droplet_kit/mappings/load_balancer_mapping.rb
+++ b/lib/droplet_kit/mappings/load_balancer_mapping.rb
@@ -1,0 +1,33 @@
+module DropletKit
+  class LoadBalancerMapping
+    include Kartograph::DSL
+
+    kartograph do
+      mapping LoadBalancer
+      root_key singular: 'load_balancer', plural: 'load_balancers', scopes: [:read]
+
+      scoped :read do
+        property :id
+        property :ip
+        property :status
+        property :created_at
+        property :region, include: RegionMapping
+      end
+
+      scoped :read, :update, :create do
+        property :name
+        property :algorithm
+        property :tag
+        property :redirect_http_to_https
+        property :droplet_ids
+        property :sticky_sessions, include: StickySessionMapping
+        property :health_check, include: HealthCheckMapping
+        property :forwarding_rules, plural: true, include: ForwardingRuleMapping
+      end
+
+      scoped  :update, :create do
+        property :region
+      end
+    end
+  end
+end

--- a/lib/droplet_kit/mappings/sticky_session_mapping.rb
+++ b/lib/droplet_kit/mappings/sticky_session_mapping.rb
@@ -1,0 +1,15 @@
+module DropletKit
+  class StickySessionMapping
+    include Kartograph::DSL
+
+    kartograph do
+      mapping StickySession
+
+      scoped :read, :create, :update do
+        property :type
+        property :cookie_name
+        property :cookie_ttl_seconds
+      end
+    end
+  end
+end

--- a/lib/droplet_kit/models/certificate.rb
+++ b/lib/droplet_kit/models/certificate.rb
@@ -1,0 +1,12 @@
+module DropletKit
+  class Certificate < BaseModel
+    attribute :id
+    attribute :name
+    attribute :not_after
+    attribute :sha1_fingerprint
+    attribute :created_at
+    attribute :private_key
+    attribute :leaf_certificate
+    attribute :certificate_chain
+  end
+end

--- a/lib/droplet_kit/models/forwarding_rule.rb
+++ b/lib/droplet_kit/models/forwarding_rule.rb
@@ -1,0 +1,10 @@
+module DropletKit
+  class ForwardingRule < BaseModel
+    attribute :entry_protocol
+    attribute :entry_port
+    attribute :target_protocol
+    attribute :target_port
+    attribute :certificate_id
+    attribute :tls_passthrough
+  end
+end

--- a/lib/droplet_kit/models/health_check.rb
+++ b/lib/droplet_kit/models/health_check.rb
@@ -1,0 +1,11 @@
+module DropletKit
+  class HealthCheck < BaseModel
+    attribute :protocol
+    attribute :port
+    attribute :path
+    attribute :check_interval_seconds
+    attribute :response_timeout_seconds
+    attribute :healthy_threshold
+    attribute :unhealthy_threshold
+  end
+end

--- a/lib/droplet_kit/models/load_balancer.rb
+++ b/lib/droplet_kit/models/load_balancer.rb
@@ -1,0 +1,17 @@
+module DropletKit
+  class LoadBalancer < BaseModel
+    attribute :id
+    attribute :ip
+    attribute :name
+    attribute :algorithm
+    attribute :status
+    attribute :created_at
+    attribute :tag
+    attribute :region
+    attribute :redirect_http_to_https
+    attribute :droplet_ids
+    attribute :sticky_sessions
+    attribute :health_check
+    attribute :forwarding_rules
+  end
+end

--- a/lib/droplet_kit/models/sticky_session.rb
+++ b/lib/droplet_kit/models/sticky_session.rb
@@ -1,0 +1,7 @@
+module DropletKit
+  class StickySession < BaseModel
+    attribute :type
+    attribute :cookie_name
+    attribute :cookie_ttl_seconds
+  end
+end

--- a/lib/droplet_kit/resources/certificate_resource.rb
+++ b/lib/droplet_kit/resources/certificate_resource.rb
@@ -1,0 +1,30 @@
+module DropletKit
+  class CertificateResource < ResourceKit::Resource
+    include ErrorHandlingResourcable
+
+    resources do
+      action :find, 'GET /v2/certificates/:id' do
+        handler(200) { |response| CertificateMapping.extract_single(response.body, :read) }
+      end
+
+      action :all, 'GET /v2/certificates' do
+        query_keys :per_page, :page
+        handler(200) { |response| CertificateMapping.extract_collection(response.body, :read) }
+      end
+
+      action :create, 'POST /v2/certificates' do
+        body { |certificate| CertificateMapping.representation_for(:create, certificate) }
+        handler(201) { |response| CertificateMapping.extract_single(response.body, :read) }
+        handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
+      end
+
+      action :delete, 'DELETE /v2/certificates/:id' do
+        handler(204) { |_| true }
+      end
+    end
+
+    def all(*args)
+      PaginatedResource.new(action(:all), self, *args)
+    end
+  end
+end

--- a/lib/droplet_kit/resources/load_balancer_resource.rb
+++ b/lib/droplet_kit/resources/load_balancer_resource.rb
@@ -1,0 +1,56 @@
+module DropletKit
+  class LoadBalancerResource < ResourceKit::Resource
+    include ErrorHandlingResourcable
+
+    resources do
+      action :find, 'GET /v2/load_balancers/:id' do
+        handler(200) { |response| LoadBalancerMapping.extract_single(response.body, :read) }
+      end
+
+      action :all, 'GET /v2/load_balancers' do
+        query_keys :per_page, :page
+        handler(200) { |response| LoadBalancerMapping.extract_collection(response.body, :read) }
+      end
+
+      action :create, 'POST /v2/load_balancers' do
+        body { |load_balancer| LoadBalancerMapping.representation_for(:create, load_balancer) }
+        handler(202) { |response| LoadBalancerMapping.extract_single(response.body, :read) }
+        handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
+      end
+
+      action :update, 'PUT /v2/load_balancers/:id' do
+        body {|load_balancer| LoadBalancerMapping.representation_for(:update, load_balancer) }
+        handler(200) { |response| LoadBalancerMapping.extract_single(response.body, :read) }
+        handler(422) { |response| ErrorMapping.fail_with(FailedUpdate, response.body) }
+      end
+
+      action :delete, 'DELETE /v2/load_balancers/:id' do
+        handler(204) { |_| true }
+      end
+
+      action :add_droplets, 'POST /v2/load_balancers/:id/droplets' do
+        body { |droplet_ids| { droplet_ids: droplet_ids }.to_json }
+        handler(204) { |_| true }
+      end
+
+      action :remove_droplets, 'DELETE /v2/load_balancers/:id/droplets' do
+        body { |droplet_ids| { droplet_ids: droplet_ids }.to_json }
+        handler(204) { |_| true }
+      end
+
+      action :add_forwarding_rules, 'POST /v2/load_balancers/:id/forwarding_rules' do
+        body { |forwarding_rules| ForwardingRuleMapping.represent_collection_for(:create, forwarding_rules) }
+        handler(204) { |_| true }
+      end
+
+      action :remove_forwarding_rules, 'DELETE /v2/load_balancers/:id/forwarding_rules' do
+        body { |forwarding_rules| ForwardingRuleMapping.represent_collection_for(:update, forwarding_rules) }
+        handler(204) { |_| true }
+      end
+    end
+
+    def all(*args)
+      PaginatedResource.new(action(:all), self, *args)
+    end
+  end
+end

--- a/spec/fixtures/certificates/all.json
+++ b/spec/fixtures/certificates/all.json
@@ -1,0 +1,16 @@
+{
+  "certificates": [
+    {
+      "id": "892071a0-bb95-49bc-8021-3afd67a210bf",
+      "name": "web-cert-01",
+      "not_after": "2017-02-22T00:23:00Z",
+      "sha1_fingerprint": "dfcc9f57d86bf58e321c2c6c31c7a971be244ac7",
+      "created_at": "2017-02-08T16:02:37Z"
+    }
+  ],
+  "links": {
+  },
+  "meta": {
+    "total": 1
+  }
+}

--- a/spec/fixtures/certificates/find.json
+++ b/spec/fixtures/certificates/find.json
@@ -1,0 +1,9 @@
+{
+  "certificate": {
+    "id": "892071a0-bb95-49bc-8021-3afd67a210bf",
+    "name": "web-cert-01",
+    "not_after": "2017-02-22T00:23:00Z",
+    "sha1_fingerprint": "dfcc9f57d86bf58e321c2c6c31c7a971be244ac7",
+    "created_at": "2017-02-08T16:02:37Z"
+  }
+}

--- a/spec/fixtures/load_balancers/all.json
+++ b/spec/fixtures/load_balancers/all.json
@@ -1,0 +1,129 @@
+{
+  "load_balancers": [
+    {
+      "id": "4de7ac8b-495b-4884-9a69-1050c6793cd6",
+      "name": "example-lb-01",
+      "ip": "104.131.186.241",
+      "algorithm": "round_robin",
+      "status": "active",
+      "created_at": "2017-02-01T22:22:58Z",
+      "forwarding_rules": [
+        {
+          "entry_protocol": "http",
+          "entry_port": 80,
+          "target_protocol": "http",
+          "target_port": 80,
+          "certificate_id": "",
+          "tls_passthrough": false
+        },
+        {
+          "entry_protocol": "https",
+          "entry_port": 444,
+          "target_protocol": "https",
+          "target_port": 443,
+          "certificate_id": "my-cert",
+          "tls_passthrough": true
+        }
+      ],
+      "health_check": {
+        "protocol": "http",
+        "port": 80,
+        "path": "/",
+        "check_interval_seconds": 10,
+        "response_timeout_seconds": 5,
+        "healthy_threshold": 5,
+        "unhealthy_threshold": 3
+      },
+      "sticky_sessions": {
+        "type": "cookies",
+        "cookie_name": "DO-LB",
+        "cookie_ttl_seconds": 5
+      },
+      "region": {
+        "name": "New York 3",
+        "slug": "nyc3",
+        "sizes": [
+          "512mb"
+        ],
+        "features": [
+          "private_networking"
+        ],
+        "available": true
+      },
+      "tag": "",
+      "droplet_ids": [
+        3164444,
+        3164445
+      ],
+      "redirect_http_to_https": false
+    },
+    {
+      "id": "3de7ac8b-495b-4884-9a69-1050c6793cd6",
+      "name": "example-lb-02",
+      "ip": "104.131.186.242",
+      "algorithm": "round_robin",
+      "status": "active",
+      "created_at": "2017-02-01T22:22:58Z",
+      "forwarding_rules": [
+        {
+          "entry_protocol": "http",
+          "entry_port": 80,
+          "target_protocol": "http",
+          "target_port": 80,
+          "certificate_id": "",
+          "tls_passthrough": false
+        }
+      ],
+      "health_check": {
+        "protocol": "http",
+        "port": 80,
+        "path": "/",
+        "check_interval_seconds": 10,
+        "response_timeout_seconds": 5,
+        "healthy_threshold": 5,
+        "unhealthy_threshold": 3
+      },
+      "sticky_sessions": {
+        "type": "cookies",
+        "cookie_name": "DO-LB",
+        "cookie_ttl_seconds": 5
+      },
+      "region": {
+        "name": "New York 3",
+        "slug": "nyc3",
+        "sizes": [
+          "512mb",
+          "1gb",
+          "2gb",
+          "4gb",
+          "8gb",
+          "16gb",
+          "m-16gb",
+          "32gb",
+          "m-32gb",
+          "48gb",
+          "m-64gb",
+          "64gb",
+          "m-128gb",
+          "m-224gb"
+        ],
+        "features": [
+          "private_networking",
+          "backups",
+          "ipv6",
+          "metadata",
+          "install_agent"
+        ],
+        "available": true
+      },
+      "tag": "",
+      "droplet_ids": [],
+      "redirect_http_to_https": true
+    }
+  ],
+  "links": {
+  },
+  "meta": {
+    "total": 1
+  }
+}

--- a/spec/fixtures/load_balancers/find.json
+++ b/spec/fixtures/load_balancers/find.json
@@ -1,0 +1,59 @@
+{
+  "load_balancer": {
+    "id": "4de7ac8b-495b-4884-9a69-1050c6793cd6",
+    "name": "example-lb-01",
+    "ip": "104.131.186.241",
+    "algorithm": "round_robin",
+    "status": "active",
+    "created_at": "2017-02-01T22:22:58Z",
+    "forwarding_rules": [
+      {
+        "entry_protocol": "http",
+        "entry_port": 80,
+        "target_protocol": "http",
+        "target_port": 80,
+        "certificate_id": "",
+        "tls_passthrough": false
+      },
+      {
+        "entry_protocol": "https",
+        "entry_port": 444,
+        "target_protocol": "https",
+        "target_port": 443,
+        "certificate_id": "my-cert",
+        "tls_passthrough": true
+      }
+    ],
+    "health_check": {
+      "protocol": "http",
+      "port": 80,
+      "path": "/",
+      "check_interval_seconds": 10,
+      "response_timeout_seconds": 5,
+      "healthy_threshold": 5,
+      "unhealthy_threshold": 3
+    },
+    "sticky_sessions": {
+      "type": "cookies",
+      "cookie_name": "DO-LB",
+      "cookie_ttl_seconds": 5
+    },
+    "region": {
+      "name": "New York 3",
+      "slug": "nyc3",
+      "sizes": [
+        "512mb"
+      ],
+      "features": [
+        "private_networking"
+      ],
+      "available": true
+    },
+    "tag": "",
+    "droplet_ids": [
+      3164444,
+      3164445
+    ],
+    "redirect_http_to_https": false
+  }
+}

--- a/spec/lib/droplet_kit/resources/certificate_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/certificate_resource_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+RSpec.describe DropletKit::CertificateResource do
+  include_context 'resources'
+
+  let(:certificate_fixture_path) { 'certificates/find' }
+  let(:base_path) { '/v2/certificates'}
+  let(:certificate_id) { '892071a0-bb95-49bc-8021-3afd67a210bf' }
+  subject(:resource) { described_class.new(connection: connection) }
+
+  RSpec::Matchers.define :match_certificate_fixture do
+    match do |certificate|
+      expect(certificate.id).to eq('892071a0-bb95-49bc-8021-3afd67a210bf')
+      expect(certificate.name).to eq('web-cert-01')
+      expect(certificate.not_after).to eq('2017-02-22T00:23:00Z')
+      expect(certificate.sha1_fingerprint).to eq('dfcc9f57d86bf58e321c2c6c31c7a971be244ac7')
+      expect(certificate.created_at).to eq('2017-02-08T16:02:37Z')
+    end
+  end
+
+  describe '#find' do
+    let(:certificate) do
+      DropletKit::Certificate.new(
+        id: '892071a0-bb95-49bc-8021-3afd67a210bf',
+        name: 'web-cert-01',
+        not_after: '2017-02-22T00:23:00Z',
+        sha1_fingerprint: 'dfcc9f57d86bf58e321c2c6c31c7a971be244ac7',
+        created_at: '2017-02-08T16:02:37Z'
+      )
+    end
+
+    it 'returns certificate' do
+      stub_do_api(File.join(base_path, certificate_id), :get).to_return(body: api_fixture(certificate_fixture_path))
+      certificate = resource.find(id: certificate_id)
+
+      expect(certificate).to match_certificate_fixture
+    end
+  end
+
+  describe '#all' do
+    let(:certificates_fixture_path) { 'certificates/all' }
+
+    it 'returns all of the certificates' do
+      stub_do_api(base_path, :get).to_return(body: api_fixture(certificates_fixture_path))
+      certificates = resource.all
+
+      expect(certificates).to all(be_kind_of(DropletKit::Certificate))
+      expect(certificates.first).to match_certificate_fixture
+    end
+
+    it_behaves_like 'a paginated index' do
+      let(:fixture_path) { certificates_fixture_path }
+      let(:api_path) { base_path }
+    end
+  end
+
+  describe '#create' do
+    let(:path) { base_path }
+
+    let(:certificate) do
+      DropletKit::Certificate.new(
+        name: 'web-cert-01',
+        private_key: '-----BEGIN PRIVATE KEY-----',
+        leaf_certificate: '-----BEGIN CERTIFICATE-----',
+        certificate_chain: '-----BEGIN CERTIFICATE-----'
+      )
+    end
+
+    it 'returns created certificate' do
+      json_body = DropletKit::CertificateMapping.representation_for(:create, certificate)
+      stub_do_api(path, :post).with(body: json_body).to_return(body: api_fixture(certificate_fixture_path), status: 201)
+
+      expect(resource.create(certificate)).to match_certificate_fixture
+    end
+
+    it_behaves_like 'an action that handles invalid parameters' do
+      let(:action) { 'create' }
+      let(:arguments) { DropletKit::Certificate.new }
+    end
+  end
+
+  describe '#delete' do
+    it 'sends a delete request for the certificate' do
+      request = stub_do_api(File.join(base_path, certificate_id), :delete)
+      resource.delete(id: certificate_id)
+
+      expect(request).to have_been_made
+    end
+  end
+end

--- a/spec/lib/droplet_kit/resources/load_balancer_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/load_balancer_resource_spec.rb
@@ -1,0 +1,213 @@
+require 'spec_helper'
+
+RSpec.describe DropletKit::LoadBalancerResource do
+  include_context 'resources'
+
+  let(:load_balancer_fixture_path) { 'load_balancers/find' }
+  let(:base_path) { '/v2/load_balancers'}
+  let(:load_balancer_id) { '37e6be88-01ec-4ec7-9bc6-a514d4719057' }
+
+  subject(:resource) { described_class.new(connection: connection) }
+
+  RSpec::Matchers.define :match_load_balancer_fixture do
+    match do |load_balancer|
+      expect(load_balancer.name).to eq('example-lb-01')
+      expect(load_balancer.id).to eq('4de7ac8b-495b-4884-9a69-1050c6793cd6')
+      expect(load_balancer.ip).to eq('104.131.186.241')
+      expect(load_balancer.algorithm).to eq('round_robin')
+      expect(load_balancer.status).to eq('active')
+      expect(load_balancer.created_at).to eq('2017-02-01T22:22:58Z')
+      expect(load_balancer.tag).to be_blank
+      expect(load_balancer.region).to be_kind_of(DropletKit::Region)
+      expect(load_balancer.region.attributes)
+        .to match(a_hash_including(slug: 'nyc3', name: 'New York 3',
+                                   available: true, sizes: ['512mb'], features: ['private_networking']))
+      expect(load_balancer.droplet_ids).to match_array([3164445, 3164444])
+      expect(load_balancer.sticky_sessions).to be_kind_of(DropletKit::StickySession)
+      expect(load_balancer.sticky_sessions.attributes)
+        .to match(a_hash_including(cookie_ttl_seconds: 5, cookie_name: 'DO-LB', type: 'cookies'))
+      expect(load_balancer.health_check).to be_kind_of(DropletKit::HealthCheck)
+      expect(load_balancer.health_check.attributes)
+        .to match(a_hash_including(protocol: 'http', port: 80, path: '/',
+                                   check_interval_seconds: 10, response_timeout_seconds: 5,
+                                   healthy_threshold: 5, unhealthy_threshold: 3))
+      expect(load_balancer.forwarding_rules.count).to eq(2)
+      expect(load_balancer.forwarding_rules.first.attributes)
+        .to match(a_hash_including(entry_protocol: 'http', entry_port: 80,
+                                   target_protocol: 'http', target_port: 80,
+                                   certificate_id: '', tls_passthrough: false))
+      expect(load_balancer.forwarding_rules.last.attributes)
+        .to match(a_hash_including(entry_protocol: 'https', entry_port: 444,
+                                   target_protocol: 'https', target_port: 443,
+                                   certificate_id: 'my-cert', tls_passthrough: true))
+    end
+  end
+
+  describe '#find' do
+    it 'returns load balancer' do
+      stub_do_api(File.join(base_path, load_balancer_id), :get).to_return(body: api_fixture(load_balancer_fixture_path))
+      load_balancer = resource.find(id: load_balancer_id)
+
+      expect(load_balancer).to match_load_balancer_fixture
+    end
+  end
+
+  describe '#all' do
+    let(:load_balancers_fixture_path) { 'load_balancers/all' }
+
+    it 'returns all of the load balancers' do
+      stub_do_api(base_path, :get).to_return(body: api_fixture(load_balancers_fixture_path))
+      load_balancers = resource.all
+
+      expect(load_balancers).to all(be_kind_of(DropletKit::LoadBalancer))
+      expect(load_balancers.first).to match_load_balancer_fixture
+    end
+
+    it_behaves_like 'a paginated index' do
+      let(:fixture_path) { load_balancers_fixture_path }
+      let(:api_path) { base_path }
+    end
+  end
+
+  context 'create and update' do
+    let(:load_balancer) do
+      DropletKit::LoadBalancer.new(
+        name: 'example-lb-01',
+        algorithm: 'round_robin',
+        droplet_ids: [ 3164444, 3164445],
+        redirect_http_to_https: true,
+        region: 'nyc1',
+        forwarding_rules: [
+          DropletKit::ForwardingRule.new(
+            entry_protocol: 'https',
+            entry_port: 444,
+            target_protocol: 'https',
+            target_port: 443,
+            certificate_id: 'my-cert',
+            tls_passthrough: false
+          )
+        ],
+        sticky_sessions: DropletKit::StickySession.new(
+          type: 'cookies',
+          cookie_name: 'DO-LB',
+          cookie_ttl_seconds: 5
+        ),
+        health_check: DropletKit::HealthCheck.new(
+          protocol: 'http',
+          port: 80,
+          path: 'index.html',
+          check_interval_seconds: 10,
+          response_timeout_seconds: 5,
+          healthy_threshold: 5,
+          unhealthy_threshold: 3
+        )
+      )
+    end
+
+    describe '#create' do
+      let(:path) { base_path }
+
+      it 'returns created load balancer' do
+        json_body = DropletKit::LoadBalancerMapping.representation_for(:create, load_balancer)
+        stub_do_api(path, :post).with(body: json_body).to_return(body: api_fixture(load_balancer_fixture_path), status: 202)
+
+        expect(resource.create(load_balancer)).to match_load_balancer_fixture
+      end
+
+      it_behaves_like 'an action that handles invalid parameters' do
+        let(:action) { 'create' }
+        let(:arguments) { DropletKit::LoadBalancer.new }
+      end
+    end
+
+    describe '#update' do
+      let(:path) { base_path }
+
+      it 'returns updated load balancer' do
+        json_body = DropletKit::LoadBalancerMapping.representation_for(:update, load_balancer)
+        stub_do_api(File.join(base_path, load_balancer_id), :put).with(body: json_body).to_return(body: api_fixture(load_balancer_fixture_path), status: 200)
+
+        expect(resource.update(load_balancer, id: load_balancer_id)).to match_load_balancer_fixture
+      end
+
+      it_behaves_like 'an action that handles invalid parameters' do
+        let(:action) { 'create' }
+        let(:arguments) { DropletKit::LoadBalancer.new }
+      end
+    end
+  end
+
+  describe '#delete' do
+    it 'sends a delete request for the load balancer' do
+      request = stub_do_api(File.join(base_path, load_balancer_id), :delete)
+      resource.delete(id: load_balancer_id)
+
+      expect(request).to have_been_made
+    end
+  end
+
+  context 'droplets' do
+    let(:droplet_id_1) { 1 }
+    let(:droplet_id_2) { 2 }
+
+    describe '#add_droplets' do
+      it 'sends a post request for the load balancer to add droplets' do
+        request = stub_do_api(File.join(base_path, load_balancer_id, 'droplets'), :post).with(body: { droplet_ids: [droplet_id_1, droplet_id_2] }.to_json)
+        resource.add_droplets([droplet_id_1, droplet_id_2], id: load_balancer_id)
+
+        expect(request).to have_been_made
+      end
+    end
+
+    describe '#remove_droplets' do
+      it 'sends a delete request for the load balancer to remove droplet' do
+        request = stub_do_api(File.join(base_path, load_balancer_id, 'droplets'), :delete).with(body: { droplet_ids: [droplet_id_1]}.to_json)
+        resource.remove_droplets([droplet_id_1], id: load_balancer_id)
+
+        expect(request).to have_been_made
+      end
+    end
+  end
+
+  context 'forwarding_rules' do
+    let(:forwarding_rule_1) do
+      DropletKit::ForwardingRule.new(
+        entry_protocol: 'tcp',
+        entry_port: 3306,
+        target_protocol: 'tcp',
+        target_port: 3306
+      )
+    end
+
+    let(:forwarding_rule_2) do
+      DropletKit::ForwardingRule.new(
+        entry_protocol: 'https',
+        entry_port: 444,
+        target_protocol: 'https',
+        target_port: 443,
+        certificate_id: '',
+        tls_passthrough: true
+      )
+    end
+
+    describe '#add_forwarding_rules' do
+      it 'sends a post request for the load balancer to add forwarding rules' do
+        json_body = DropletKit::ForwardingRuleMapping.represent_collection_for(:create, [forwarding_rule_1, forwarding_rule_2])
+        request = stub_do_api(File.join(base_path, load_balancer_id, 'forwarding_rules'), :post).with(body: json_body)
+        resource.add_forwarding_rules([forwarding_rule_1, forwarding_rule_2], id: load_balancer_id)
+
+        expect(request).to have_been_made
+      end
+    end
+
+    describe '#remove_forwarding_rules' do
+      it 'sends a delete request for the load balancer to remove forwarding rule' do
+        json_body = DropletKit::ForwardingRuleMapping.represent_collection_for(:update, [forwarding_rule_1])
+        request = stub_do_api(File.join(base_path, load_balancer_id, 'forwarding_rules'), :delete).with(body: json_body)
+        resource.remove_forwarding_rules([forwarding_rule_1], id: load_balancer_id)
+
+        expect(request).to have_been_made
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,7 @@ require 'addressable/uri'
 require 'droplet_kit'
 require 'webmock/rspec'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(SimpleCov::Formatter::HTMLFormatter)
 
 Dir['./spec/support/**/*.rb'].each do |file|
   require file


### PR DESCRIPTION
This changeset adds support for `Certificate` and `LoadBalancer` resources.

## Certificate resource

```ruby
client = DropletKit::Client.new(access_token: 'TOKEN')
client.certificates #=> DropletKit::CertificateResource
```

Actions supported:

* `client.certificates.find(id: 'id')`
* `client.certificates.all()`
* `client.certificates.create(certificate)`
* `client.certificates.delete(id: 'id')`

 
## Load balancer resource
```ruby
client = DropletKit::Client.new(access_token: 'TOKEN')
client.load_balancers #=> DropletKit::LoadBalancerResource
```

Actions supported:

* `client.load_balancers.find(id: 'id')`
* `client.load_balancers.all()`
* `client.load_balancers.create(load_balancer)`
* `client.load_balancers.update(load_balancer, id: 'id')`
* `client.load_balancers.delete(id: 'id')`
* `client.load_balancers.add_droplets([droplet.id], id: 'id')`
* `client.load_balancers.remove_droplets([droplet.id], id: 'id')`
* `client.load_balancers.add_forwarding_rules([forwarding_rule], id: 'id')`
* `client.load_balancers.remove_forwarding_rules([forwarding_rule], id: 'id')`