### PR TITLE
Add `rb-readline` as a development dependancy

### DIFF
--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0.0"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "rb-readline"
 
   # FakeServe
   spec.add_development_dependency 'sinatra', '~> 1.4'


### PR DESCRIPTION
* Allows the usage of `pry` without realine support
being compiled as part of the ruby install
* Useful for rbenv or rvm users