### PR TITLE
Deprecate tag rename (PUT /v2/tags/:name)

### DIFF
--- a/lib/droplet_kit/mappings/tag_mapping.rb
+++ b/lib/droplet_kit/mappings/tag_mapping.rb
@@ -6,7 +6,7 @@ module DropletKit
       mapping Tag
       root_key plural: 'tags', singular: 'tag', scopes: [:read]
 
-      scoped :read, :create, :update do
+      scoped :read, :create do
         property :name
       end
 

--- a/lib/droplet_kit/resources/tag_resource.rb
+++ b/lib/droplet_kit/resources/tag_resource.rb
@@ -18,11 +18,6 @@ module DropletKit
         handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
       end
 
-      action :update, 'PUT /v2/tags/:name' do
-        body { |object| TagMapping.representation_for(:update, object) }
-        handler(200) { |response| TagMapping.extract_single(response.body, :read) }
-      end
-
       action :delete, 'DELETE /v2/tags/:name' do
         handler(204) { |_| true }
         handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }

--- a/spec/lib/droplet_kit/resources/tag_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/tag_resource_spec.rb
@@ -67,20 +67,6 @@ describe DropletKit::TagResource do
     end
   end
 
-  describe '#update' do
-    it 'updateds a tag' do
-      tag = DropletKit::Tag.new(name: 'old-testing-1')
-      tag.name = 'testing-1'
-
-      request = stub_do_api('/v2/tags/old-testing-1', :put)
-        .with(body: DropletKit::TagMapping.representation_for(:update, tag))
-        .to_return(body: api_fixture('tags/find'))
-
-      tag = resource.update(tag, name: 'old-testing-1')
-      expect(tag.name).to eq('testing-1')
-    end
-  end
-
   describe '#delete' do
     it 'deletes a tag' do
       request = stub_do_api('/v2/tags/testing-1', :delete)


### PR DESCRIPTION
Per [our changelog](https://developers.digitalocean.com/documentation/changelog/api-v2/deprecating-update-tag/), tag rename will be deprecated on April 26, 2017.

cc @mauricio @hugocorbucci @magicgrl111 