### PR TITLE
Add support of all Rails 5 releases

### DIFF
--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0.3'
   spec.add_dependency "resource_kit", '~> 0.1.5'
   spec.add_dependency "kartograph", '~> 0.2.3'
-  spec.add_dependency "activesupport", '> 3.0', '< 5.1'
+  spec.add_dependency "activesupport", '> 3.0', '< 6'
   spec.add_dependency "faraday", '~> 0.9.1'
 
   spec.add_development_dependency "bundler", ">= 1.11.0"


### PR DESCRIPTION
I think there is no use to strictly check minor rails release.
Currently with '< 5.1' gem cannot be used in any Rails newer than 5.0