### PR TITLE
Support updating TTLs for domain records.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ client.domain_records #=> DropletKit::DomainRecordResource
 domain_record = DropletKit::DomainRecord.new(
   type: 'CNAME',
   name: 'www',
-  data: '@'
+  data: '@',
+  ttl: 1800
 )
 ```
 

--- a/lib/droplet_kit/mappings/domain_record_mapping.rb
+++ b/lib/droplet_kit/mappings/domain_record_mapping.rb
@@ -12,6 +12,7 @@ module DropletKit
       property :data, scopes: [:read, :create, :update]
       property :priority, scopes: [:read, :create, :update]
       property :port, scopes: [:read, :create, :update]
+      property :ttl, scopes: [:read, :create, :update]
       property :weight, scopes: [:read, :create, :update]
     end
   end

--- a/lib/droplet_kit/models/domain_record.rb
+++ b/lib/droplet_kit/models/domain_record.rb
@@ -6,6 +6,7 @@ module DropletKit
     attribute :data
     attribute :priority
     attribute :port
+    attribute :ttl
     attribute :weight
   end
 end

--- a/spec/fixtures/domain_records/all.json
+++ b/spec/fixtures/domain_records/all.json
@@ -7,6 +7,7 @@
       "data": "8.8.8.8",
       "priority": null,
       "port": null,
+      "ttl": 1800,
       "weight": null
     },
     {
@@ -16,6 +17,7 @@
       "data": "NS1.DIGITALOCEAN.COM.",
       "priority": null,
       "port": null,
+      "ttl": 1800,
       "weight": null
     },
     {
@@ -25,6 +27,7 @@
       "data": "NS2.DIGITALOCEAN.COM.",
       "priority": null,
       "port": null,
+      "ttl": 1800,
       "weight": null
     },
     {
@@ -34,6 +37,7 @@
       "data": "NS3.DIGITALOCEAN.COM.",
       "priority": null,
       "port": null,
+      "ttl": 1800,
       "weight": null
     },
     {
@@ -43,6 +47,7 @@
       "data": "@",
       "priority": null,
       "port": null,
+      "ttl": 1800,
       "weight": null
     }
   ],

--- a/spec/fixtures/domain_records/create.json
+++ b/spec/fixtures/domain_records/create.json
@@ -6,6 +6,7 @@
     "data": "@",
     "priority": null,
     "port": null,
+    "ttl": 90,
     "weight": null
   }
 }

--- a/spec/fixtures/domain_records/find.json
+++ b/spec/fixtures/domain_records/find.json
@@ -6,6 +6,7 @@
     "data": "@",
     "priority": null,
     "port": null,
+    "ttl": 1800,
     "weight": null
   }
 }

--- a/spec/fixtures/domain_records/update.json
+++ b/spec/fixtures/domain_records/update.json
@@ -6,6 +6,7 @@
     "data": "@",
     "priority": null,
     "port": null,
+    "ttl": 1800,
     "weight": null
   }
 }

--- a/spec/lib/droplet_kit/resources/domain_record_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/domain_record_resource_spec.rb
@@ -29,12 +29,14 @@ RSpec.describe DropletKit::DomainRecordResource do
       domain_record = DropletKit::DomainRecord.new(
         type: 'CNAME',
         name: 'www',
-        data: '@'
+        data: '@',
+        ttl: 90
       )
       as_hash = DropletKit::DomainRecordMapping.hash_for(:create, domain_record)
       expect(as_hash['type']).to eq('CNAME')
       expect(as_hash['name']).to eq('www')
       expect(as_hash['data']).to eq('@')
+      expect(as_hash['ttl']).to eq(90)
 
       as_json = DropletKit::DomainRecordMapping.representation_for(:create, domain_record)
       stub_do_api('/v2/domains/example.com/records', :post).with(body: as_json).to_return(body: response, status: 201)
@@ -44,6 +46,7 @@ RSpec.describe DropletKit::DomainRecordResource do
       expect(created_domain_record.name).to eq('www')
       expect(created_domain_record.type).to eq('CNAME')
       expect(created_domain_record.data).to eq('@')
+      expect(created_domain_record.ttl).to eq(90)
     end
   end
 
@@ -90,6 +93,7 @@ RSpec.describe DropletKit::DomainRecordResource do
       expect(updated_domain_record.name).to eq('lol')
       expect(updated_domain_record.type).to eq('CNAME')
       expect(updated_domain_record.data).to eq('@')
+      expect(updated_domain_record.ttl).to eq(1800)
     end
   end
 end


### PR DESCRIPTION
Fixes: #119

https://developers.digitalocean.com/documentation/changelog/api-v2/configurable-ttl-for-domain-records/