### PR TITLE
Add support to create/update/show CAA domain records.

### DIFF
--- a/lib/droplet_kit/mappings/domain_record_mapping.rb
+++ b/lib/droplet_kit/mappings/domain_record_mapping.rb
@@ -14,6 +14,8 @@ module DropletKit
       property :port, scopes: [:read, :create, :update]
       property :ttl, scopes: [:read, :create, :update]
       property :weight, scopes: [:read, :create, :update]
+      property :flags, scopes: [:read, :create, :update]
+      property :tag, scopes: [:read, :create, :update]
     end
   end
 end

--- a/lib/droplet_kit/models/domain_record.rb
+++ b/lib/droplet_kit/models/domain_record.rb
@@ -8,5 +8,7 @@ module DropletKit
     attribute :port
     attribute :ttl
     attribute :weight
+    attribute :flags
+    attribute :tag
   end
 end


### PR DESCRIPTION
**Sample of CAA domain record:**

```
> domain_record = DropletKit::DomainRecord.new(type: 'CAA', name: '@', data: 'letsencrypt.org.', tag: 'issue', flags: 0)
=> <DropletKit::DomainRecord {:@type=>"CAA", :@name=>"@", :@data=>"letsencrypt.org.", :@ttl=>nil, :@id=>nil, :@priority=>nil, :@port=>nil, :@weight=>nil, :@flags=>0, :@tag=>"issue"}>
```

** Sample of creating CAA domain record:**

```
client.domain_records.create(domain_record, for_domain: 'somedomain.com')
=> <DropletKit::DomainRecord {:@type=>"CAA", :@name=>"@", :@data=>"letsencrypt.org", :@ttl=>1800, :@id=>73489237487, :@priority=>nil, :@port=>nil, :@weight=>nil, :@flags=>0, :@tag=>"issue"}>
```