### PR TITLE
Update tag/untag resources with string resource_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 2.2.2
+* Fix tag / untag resources request body
+
 ### Version 2.2.1
 * Relaxed faraday version requirement
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Actions supported:
 
 * `client.tags.all()`
 * `client.tags.find(name: 'name')`
-* `client.tags.create(tag)
+* `client.tags.create(DropletKit::Tag.new(name: 'name'))`
 * `client.tags.delete(name: 'name')`
 * `client.tags.tag_resources(name: 'name', resources: [{ resource_id => 'droplet_id', resource_type: 'droplet' }])`
 * `client.tags.untag_resources(name 'name', resources: [{ resource_id => 'droplet_id', resource_type: 'droplet' }])`
@@ -426,6 +426,6 @@ Bump the [version](https://github.com/digitalocean/droplet_kit/blob/master/lib/d
 that are being released to the [CHANGELOG](https://github.com/digitalocean/droplet_kit/blob/master/CHANGELOG.md) and
 if you have already done the rubygems sign in from the account, just run `rake release`, if not continue reading.
 
-Find the password on DO's lastpass account (search for rubygems), sign in with the user (run gem `gem push` and it 
+Find the password on DO's lastpass account (search for rubygems), sign in with the user (run gem `gem push` and it
 will ask you for DO's email and password you found on lastpass), the `gem push` command will fail, ignore. Now just run
 `rake release` and the gem will be pushed to rubygems.

--- a/lib/droplet_kit/resources/tag_resource.rb
+++ b/lib/droplet_kit/resources/tag_resource.rb
@@ -25,13 +25,27 @@ module DropletKit
 
       action :tag_resources, 'POST /v2/tags/:name/resources' do
         verb :post
-        body { |hash| { resources: hash[:resources] }.to_json }
+        body do |hash|
+          resources = hash[:resources].map do |resource|
+            resource[:resource_id] = resource[:resource_id].to_s
+            resource
+          end
+
+          { resources: resources }.to_json
+        end
         handler(204) { |_| true }
       end
 
       action :untag_resources, 'DELETE /v2/tags/:name/resources' do
         verb :delete
-        body { |hash| { resources: hash[:resources] }.to_json }
+        body do |hash|
+          resources = hash[:resources].map do |resource|
+            resource[:resource_id] = resource[:resource_id].to_s
+            resource
+          end
+
+          { resources: resources }.to_json
+        end
         handler(204) { |_| true }
       end
     end


### PR DESCRIPTION
According to https://developers.digitalocean.com/documentation/v2/#tag-a-resource, we expect a string `resource_id` when sending a tag / untag resource request. Given Ruby is a little more forgiving in sending requests, this just ensures that `resource_id` is always a string.

Fixes #136 