### PR TITLE
Add user agent header

### DIFF
--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -1,3 +1,5 @@
+require_relative 'version'
+
 require 'faraday'
 
 module DropletKit
@@ -61,7 +63,8 @@ module DropletKit
         url: DIGITALOCEAN_API,
         headers: {
           content_type: 'application/json',
-          authorization: "Bearer #{access_token}"
+          authorization: "Bearer #{access_token}",
+          user_agent: "droplet_kit (https://github.com/digitalocean/droplet_kit);#{DropletKit::VERSION};ruby #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL};#{RUBY_PLATFORM}"
         }
       }
     end


### PR DESCRIPTION
To better understand usage of our API we'll need to start digging into user agent headers.

This proposed structure is parseable and follows the format of:

```
project name (GitHub url if there is one);library version;language version;os
droplet_kit (https://github.com/digitalocean/droplet_kit);2.2.2;ruby 2.5.0-p0;x86_64-darwin17
```

We'll need to sync with the folks at [godo](https://github.com/digitalocean/godo/blob/d1aa3987e94178bdc3d1ec8de61d257325d76627/godo.go#L22) as well.