### PR TITLE
Add support for custom User-Agent

### DIFF
--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -4,10 +4,11 @@ module DropletKit
   class Client
     DIGITALOCEAN_API = 'https://api.digitalocean.com'
 
-    attr_reader :access_token
+    attr_reader :access_token, :user_agent
 
     def initialize(options = {})
       @access_token = options.with_indifferent_access[:access_token]
+      @user_agent = options.with_indifferent_access[:user_agent]
     end
 
     def connection
@@ -56,6 +57,10 @@ module DropletKit
       @resources ||= {}
     end
 
+    def default_user_agent
+      "DropletKit/#{DropletKit::VERSION} Faraday/#{Faraday::VERSION}"
+    end
+
     private
 
     def connection_options
@@ -63,7 +68,8 @@ module DropletKit
         url: DIGITALOCEAN_API,
         headers: {
           content_type: 'application/json',
-          authorization: "Bearer #{access_token}"
+          authorization: "Bearer #{access_token}",
+          user_agent: "#{user_agent} #{default_user_agent}".strip
         }
       }
     end

--- a/spec/lib/droplet_kit/client_spec.rb
+++ b/spec/lib/droplet_kit/client_spec.rb
@@ -39,6 +39,21 @@ RSpec.describe DropletKit::Client do
       expect(client.connection.headers['Content-Type']).to eq("application/json")
     end
 
+    context 'with default user agent' do
+      it 'contains the version of DropletKit and Faraday' do
+        stub_const('DropletKit::VERSION', '1.2.3')
+        stub_const('Faraday::VERSION', '1.2.3')
+        expect(client.connection.headers['User-Agent']).to eq('DropletKit/1.2.3 Faraday/1.2.3')
+      end
+    end
+
+    context 'with user provided user agent' do
+      it 'includes their agent string as well' do
+        client = DropletKit::Client.new(access_token: 'bunk', user_agent: 'tugboat')
+        expect(client.connection.headers['User-Agent']).to include('tugboat')
+      end
+    end
+
     it 'allows access to faraday instance' do
       client.connection.use AcmeApp::CustomLogger
       expect(client.connection.builder.handlers).to include(AcmeApp::CustomLogger)


### PR DESCRIPTION
This PR implements support for a custom User-Agent and adds a default User-Agent for identifying requests made with DropletKit.

Effectively superset of #139, cc @eddiezane @andrewsomething 