### PR TITLE
Add cluster "all" functionality

### DIFF
--- a/lib/droplet_kit/resources/kubernetes_resource.rb
+++ b/lib/droplet_kit/resources/kubernetes_resource.rb
@@ -4,6 +4,7 @@ module DropletKit
 
     resources do
       action :all, 'GET /v2/kubernetes/clusters' do
+        handler(200) { |response| KubernetesMapping.extract_collection(response.body, :read) }
       end
 
       action :find, 'GET /v2/kubernetes/clusters/:cluster_id' do
@@ -44,6 +45,10 @@ module DropletKit
 
       action :get_options, 'GET /v2/kubernetes/options' do
       end
+    end
+
+    def all(*args)
+      PaginatedResource.new(action(:all), self, *args)
     end
   end
 end

--- a/lib/droplet_kit/resources/kubernetes_resource.rb
+++ b/lib/droplet_kit/resources/kubernetes_resource.rb
@@ -4,6 +4,7 @@ module DropletKit
 
     resources do
       action :all, 'GET /v2/kubernetes/clusters' do
+        query_keys :per_page, :page, :tag_name
         handler(200) { |response| KubernetesMapping.extract_collection(response.body, :read) }
       end
 

--- a/spec/fixtures/kubernetes/all.json
+++ b/spec/fixtures/kubernetes/all.json
@@ -1,0 +1,70 @@
+{
+  "kubernetes_clusters": [
+    {
+      "id": "cluster-1-id",
+      "name": "k8s-1-12-1-do-2-nyc1-1542400893024",
+      "region": "nyc1",
+      "version": "1.12.1-do.2",
+      "cluster_subnet": "10.244.0.0/16",
+      "service_subnet": "",
+      "ipv4": "104.248.50.56",
+      "endpoint": "",
+      "tags": [
+        "scott-k8",
+        "k8s",
+        "k8s:6afca5dd-7b87-43fd-887a-308457e21115"
+      ],
+      "node_pools": [
+        {
+          "id": "e8149cc3-d862-403a-95c3-33bb7ed5c530",
+          "name": "k8s-1-12-1-do-2-nyc1-1542400893024-1",
+          "size": "s-1vcpu-1gb",
+          "count": 3,
+          "tags": [
+            "k8s",
+            "k8s:6afca5dd-7b87-43fd-887a-308457e21115",
+            "k8s:worker",
+            "scott-k8"
+          ],
+          "nodes": [
+            {
+              "id": "06a74b77-5a1d-47e4-8b04-d3e0d248ff72",
+              "name": "nervous-bartik-33bs",
+              "status": {
+                "state": "running"
+              },
+              "created_at": "2018-11-16T20:41:44Z",
+              "updated_at": "2018-11-16T20:44:27Z"
+            },
+            {
+              "id": "114f9605-2887-47e1-9b6b-a5e8c1f400bb",
+              "name": "nervous-bartik-33bk",
+              "status": {
+                "state": "running"
+              },
+              "created_at": "2018-11-16T20:41:44Z",
+              "updated_at": "2018-11-16T20:44:27Z"
+            },
+            {
+              "id": "9090cfaa-d138-4857-9ea3-4b555b76e0f1",
+              "name": "nervous-bartik-33b5",
+              "status": {
+                "state": "running"
+              },
+              "created_at": "2018-11-16T20:41:44Z",
+              "updated_at": "2018-11-16T20:44:27Z"
+            }
+          ]
+        }
+      ],
+      "status": {
+        "state": "running"
+      },
+      "created_at": "2018-11-16T20:41:43Z",
+      "updated_at": "2018-11-16T20:44:27Z"
+    }
+  ],
+  "meta": {
+    "total": 1
+  }
+}

--- a/spec/fixtures/kubernetes/all.json
+++ b/spec/fixtures/kubernetes/all.json
@@ -2,34 +2,34 @@
   "kubernetes_clusters": [
     {
       "id": "cluster-1-id",
-      "name": "k8s-1-12-1-do-2-nyc1-1542400893024",
+      "name": "test-cluster",
       "region": "nyc1",
       "version": "1.12.1-do.2",
       "cluster_subnet": "10.244.0.0/16",
       "service_subnet": "",
-      "ipv4": "104.248.50.56",
+      "ipv4": "0.0.0.0",
       "endpoint": "",
       "tags": [
-        "scott-k8",
+        "test-k8",
         "k8s",
-        "k8s:6afca5dd-7b87-43fd-887a-308457e21115"
+        "k8s:cluster-1-id"
       ],
       "node_pools": [
         {
-          "id": "e8149cc3-d862-403a-95c3-33bb7ed5c530",
-          "name": "k8s-1-12-1-do-2-nyc1-1542400893024-1",
+          "id": "node-pool-id",
+          "name": "node-pool-1",
           "size": "s-1vcpu-1gb",
           "count": 3,
           "tags": [
             "k8s",
-            "k8s:6afca5dd-7b87-43fd-887a-308457e21115",
+            "k8s:node-pool-id",
             "k8s:worker",
-            "scott-k8"
+            "test-k8"
           ],
           "nodes": [
             {
-              "id": "06a74b77-5a1d-47e4-8b04-d3e0d248ff72",
-              "name": "nervous-bartik-33bs",
+              "id": "node-1-id",
+              "name": "node-1",
               "status": {
                 "state": "running"
               },
@@ -37,8 +37,8 @@
               "updated_at": "2018-11-16T20:44:27Z"
             },
             {
-              "id": "114f9605-2887-47e1-9b6b-a5e8c1f400bb",
-              "name": "nervous-bartik-33bk",
+              "id": "node-2-id",
+              "name": "node-2",
               "status": {
                 "state": "running"
               },
@@ -46,8 +46,8 @@
               "updated_at": "2018-11-16T20:44:27Z"
             },
             {
-              "id": "9090cfaa-d138-4857-9ea3-4b555b76e0f1",
-              "name": "nervous-bartik-33b5",
+              "id": "node-3-id",
+              "name": "node-3",
               "status": {
                 "state": "running"
               },

--- a/spec/fixtures/kubernetes/all_empty.json
+++ b/spec/fixtures/kubernetes/all_empty.json
@@ -1,0 +1,7 @@
+{
+  "kubernetes_clusters": [
+  ],
+  "meta": {
+    "total": 0
+  }
+}

--- a/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe DropletKit::KubernetesResource do
       expect(cluster.cluster_subnet).to eq("10.244.0.0/16")
       expect(cluster.ipv4).to eq("0.0.0.0")
       expect(cluster.tags).to match_array(["test-k8", "k8s", "k8s:cluster-1-id"])
+      expect(cluster.node_pools.count).to eq(1)
     end
 
     it 'returns an empty array of droplets' do

--- a/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe DropletKit::KubernetesResource do
+  subject(:resource) { described_class.new(connection: connection) }
+  include_context 'resources'
+
+  describe '#all' do
+    it 'returns all of the clusters' do
+      stub_do_api('/v2/kubernetes/clusters', :get).to_return(body: api_fixture('kubernetes/all'))
+      clusters = resource.all
+      expect(clusters).to all(be_kind_of(DropletKit::Kubernetes))
+
+      cluster = clusters.first
+      expect(cluster.id).to eq("cluster-1-id")
+    end
+
+    it 'returns an empty array of droplets' do
+      stub_do_api('/v2/kubernetes/clusters', :get).to_return(body: api_fixture('kubernetes/all_empty'))
+      clusters = resource.all.map(&:id)
+      expect(clusters).to be_empty
+    end
+
+    it_behaves_like 'a paginated index' do
+      let(:fixture_path) { 'kubernetes/all' }
+      let(:api_path) { '/v2/kubernetes/clusters' }
+    end
+  end
+end

--- a/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
@@ -11,7 +11,14 @@ RSpec.describe DropletKit::KubernetesResource do
       expect(clusters).to all(be_kind_of(DropletKit::Kubernetes))
 
       cluster = clusters.first
+
       expect(cluster.id).to eq("cluster-1-id")
+      expect(cluster.name).to eq("test-cluster")
+      expect(cluster.region).to eq("nyc1")
+      expect(cluster.version).to eq("1.12.1-do.2")
+      expect(cluster.cluster_subnet).to eq("10.244.0.0/16")
+      expect(cluster.ipv4).to eq("0.0.0.0")
+      expect(cluster.tags).to match_array(["test-k8", "k8s", "k8s:cluster-1-id"])
     end
 
     it 'returns an empty array of droplets' do


### PR DESCRIPTION
* Adds the ability to get a list of all kubernetes clusters running for a user.
* Adds specs to test the clusters being returned.

api endpoint wrapped: `v2/kubernetes/clusters`