### PR TITLE
Added Kubernetes Node Pools

### DIFF
--- a/lib/droplet_kit.rb
+++ b/lib/droplet_kit.rb
@@ -44,6 +44,8 @@ module DropletKit
   autoload :FirewallPendingChange, 'droplet_kit/models/firewall_pending_change'
   autoload :CDN, 'droplet_kit/models/cdn'
   autoload :Kubernetes, 'droplet_kit/models/kubernetes'
+  autoload :KubernetesNodePool, 'droplet_kit/models/kubernetes_node_pool'
+  autoload :KubernetesNode, 'droplet_kit/models/kubernetes_node'
 
   # Resources
   autoload :DropletResource, 'droplet_kit/resources/droplet_resource'
@@ -109,6 +111,8 @@ module DropletKit
   autoload :FirewallPendingChangeMapping, 'droplet_kit/mappings/firewall_pending_change_mapping'
   autoload :CDNMapping, 'droplet_kit/mappings/cdn_mapping'
   autoload :KubernetesMapping, 'droplet_kit/mappings/kubernetes_mapping'
+  autoload :KubernetesNodePoolMapping, 'droplet_kit/mappings/kubernetes_node_pool_mapping'
+  autoload :KubernetesNodeMapping, 'droplet_kit/mappings/kubernetes_node_mapping'
 
   # Utils
   autoload :PaginatedResource, 'droplet_kit/paginated_resource'

--- a/lib/droplet_kit/mappings/kubernetes_node_mapping.rb
+++ b/lib/droplet_kit/mappings/kubernetes_node_mapping.rb
@@ -1,0 +1,16 @@
+module DropletKit
+  class KubernetesNodeMapping
+    include Kartograph::DSL
+
+    kartograph do
+      mapping KubernetesNode
+
+      property :id, scopes: [:read]
+      property :name, scopes: [:read]
+      property :status, scopes: [:read]
+      property :created_at, scopes: [:read]
+      property :updated_at, scopes: [:read]
+    end
+  end
+end
+

--- a/lib/droplet_kit/mappings/kubernetes_node_pool_mapping.rb
+++ b/lib/droplet_kit/mappings/kubernetes_node_pool_mapping.rb
@@ -1,0 +1,19 @@
+module DropletKit
+  class KubernetesNodePoolMapping
+    include Kartograph::DSL
+
+    kartograph do
+      mapping KubernetesNodePool
+      root_key plural: 'node_pools', scopes: [:read]
+
+      property :id, scopes: [:read]
+      property :name, scopes: [:read]
+      property :size, scopes: [:read]
+      property :count, scopes: [:read]
+      property :tags, scopes: [:read]
+
+      property :nodes, plural: true, scopes: [:read], include: KubernetesNodeMapping
+    end
+  end
+end
+

--- a/lib/droplet_kit/models/kubernetes_node.rb
+++ b/lib/droplet_kit/models/kubernetes_node.rb
@@ -1,0 +1,7 @@
+module DropletKit
+  class KubernetesNode < BaseModel
+    [:id, :name, :status, :created_at, :updated_at].each do |key|
+      attribute(key)
+    end
+  end
+end

--- a/lib/droplet_kit/models/kubernetes_node_pool.rb
+++ b/lib/droplet_kit/models/kubernetes_node_pool.rb
@@ -1,0 +1,7 @@
+module DropletKit
+  class KubernetesNodePool < BaseModel
+    [:id, :name, :size, :count, :tags, :nodes].each do |key|
+      attribute(key)
+    end
+  end
+end

--- a/lib/droplet_kit/resources/kubernetes_resource.rb
+++ b/lib/droplet_kit/resources/kubernetes_resource.rb
@@ -25,6 +25,7 @@ module DropletKit
       end
 
       action :cluster_node_pools, 'GET /v2/kubernetes/clusters/:cluster_id/node_pools' do
+        handler(200) { |response| KubernetesNodePoolMapping.extract_collection(response.body, :read) }
       end
 
       action :cluster_find_node_pool, 'GET /v2/kubernetes/clusters/:cluster_id/node_pools/:pool_id' do

--- a/spec/fixtures/kubernetes/cluster_node_pools.json
+++ b/spec/fixtures/kubernetes/cluster_node_pools.json
@@ -1,0 +1,33 @@
+{
+  "node_pools": [
+    {
+      "id": "0a209365-2fac-465e-a959-bb91f232923a",
+      "name": "k8s-1-12-1-do-1-nyc1-1540837045848-1",
+      "size": "s-4vcpu-8gb",
+      "count": 2,
+      "tags": [
+        "omar-left-his-mark"
+      ],
+      "nodes": [
+        {
+          "id": "94bf2bde-e135-11e8-81bd-3cfdfe9e5ea0",
+          "name": "nostalgic-buck-5y1",
+          "status": {
+            "state": "running"
+          },
+          "created_at": "2018-10-29T18:17:48Z",
+          "updated_at": "2018-11-05T20:01:27Z"
+        },
+        {
+          "id": "94bf2c6f-e135-11e8-81bd-3cfdfe9e5ea0",
+          "name": "nostalgic-buck-5yz",
+          "status": {
+            "state": "running"
+          },
+          "created_at": "2018-10-29T18:17:48Z",
+          "updated_at": "2018-11-05T20:01:27Z"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/lib/droplet_kit/kubernetes_resource_spec.rb
+++ b/spec/lib/droplet_kit/kubernetes_resource_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'pry'
+
+RSpec.describe DropletKit::KubernetesResource do
+  subject(:resource) { described_class.new(connection: connection) }
+  let(:kubernetes_node_pool_attributes) { DropletKit::KubernetesNodePool.new.attributes }
+  include_context 'resources'
+
+  describe "cluster_node_pools" do
+    it 'returns the node_pools for a cluster' do
+      cluster_id = 42
+      stub_do_api("/v2/kubernetes/clusters/#{cluster_id}/node_pools", :get).to_return(body: api_fixture('kubernetes/cluster_node_pools'))
+      node_pools= resource.cluster_node_pools(cluster_id: cluster_id)
+      node_pools.each do |pool|
+        expect(pool).to be_kind_of(DropletKit::KubernetesNodePool)
+        expect(pool.attributes.keys).to eq kubernetes_node_pool_attributes.keys
+      end
+      check_node_pools(node_pools)
+    end
+  end
+
+end
+
+def check_node_pools(pools)
+  expect(pools.length).to eq 1
+  expect(pools[0]["id"]).to eq "0a209365-2fac-465e-a959-bb91f232923a"
+  expect(pools[0]["name"]).to eq "k8s-1-12-1-do-1-nyc1-1540837045848-1"
+  expect(pools[0]["size"]).to eq "s-4vcpu-8gb"
+  expect(pools[0]["count"]).to eq 2
+  expect(pools[0]["tags"]).to eq [ "omar-left-his-mark" ]
+  expect(pools[0]["nodes"].length).to eq 2
+end

--- a/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 RSpec.describe DropletKit::KubernetesResource do
   subject(:resource) { described_class.new(connection: connection) }
@@ -15,18 +14,15 @@ RSpec.describe DropletKit::KubernetesResource do
         expect(pool).to be_kind_of(DropletKit::KubernetesNodePool)
         expect(pool.attributes.keys).to eq kubernetes_node_pool_attributes.keys
       end
-      check_node_pools(node_pools)
+      expect(node_pools.length).to eq 1
+      expect(node_pools.first["id"]).to eq "0a209365-2fac-465e-a959-bb91f232923a"
+      expect(node_pools.first["name"]).to eq "k8s-1-12-1-do-1-nyc1-1540837045848-1"
+      expect(node_pools.first["size"]).to eq "s-4vcpu-8gb"
+      expect(node_pools.first["count"]).to eq 2
+      expect(node_pools.first["tags"]).to eq [ "omar-left-his-mark" ]
+      expect(node_pools.first["nodes"].length).to eq 2
     end
   end
 
 end
 
-def check_node_pools(pools)
-  expect(pools.length).to eq 1
-  expect(pools[0]["id"]).to eq "0a209365-2fac-465e-a959-bb91f232923a"
-  expect(pools[0]["name"]).to eq "k8s-1-12-1-do-1-nyc1-1540837045848-1"
-  expect(pools[0]["size"]).to eq "s-4vcpu-8gb"
-  expect(pools[0]["count"]).to eq 2
-  expect(pools[0]["tags"]).to eq [ "omar-left-his-mark" ]
-  expect(pools[0]["nodes"].length).to eq 2
-end


### PR DESCRIPTION
This adds wrapper code over the Digital Ocean  Kubernetes API for a K8 Cluster's NodePools.

Endpoint: `GET /v2/kubernetes/clusters/:cluster_id/node_pools`
Response: https://github.com/digitalocean/droplet_kit/blob/81e2d208a9b8ef9e21bc503c78e0e57dff2f915f/spec/fixtures/kubernetes/cluster_node_pools.json

