### PR TITLE
K8s/add delete cluster

### DIFF
--- a/lib/droplet_kit/resources/kubernetes_resource.rb
+++ b/lib/droplet_kit/resources/kubernetes_resource.rb
@@ -22,10 +22,7 @@ module DropletKit
       end
 
       action :delete, 'DELETE /v2/kubernetes/clusters/:id' do
-        handler(204) { |response|
-          puts response.body
-          true
-        }
+        handler(202) { |response| true }
       end
 
       action :cluster_node_pools, 'GET /v2/kubernetes/clusters/:cluster_id/node_pools' do

--- a/lib/droplet_kit/resources/kubernetes_resource.rb
+++ b/lib/droplet_kit/resources/kubernetes_resource.rb
@@ -21,7 +21,11 @@ module DropletKit
       action :upgrade, 'GET /v2/kubernetes/clusters/:cluster_id/upgrade' do
       end
 
-      action :delete, 'DELETE /v2/kubernetes/clusters/:cluster_id' do
+      action :delete, 'DELETE /v2/kubernetes/clusters/:id' do
+        handler(204) { |response|
+          puts response.body
+          true
+        }
       end
 
       action :cluster_node_pools, 'GET /v2/kubernetes/clusters/:cluster_id/node_pools' do

--- a/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe DropletKit::KubernetesResource do
+  subject(:resource) { described_class.new(connection: connection) }
+  include_context 'resources'
+
+  describe '#delete' do
+    it 'sends a delete request for a cluster' do
+      request = stub_do_api('/v2/kubernetes/clusters/23', :delete).to_return(status: 202)
+      response = resource.delete(id: 23)
+
+      expect(request).to have_been_made
+      expect(response).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
this adds the delete functionality for the kubernetes clusters.

api wrapped: `DELETE /v2/kubernetes/clusters/:cluster_id`

closes issue: https://github.internal.digitalocean.com/digitalocean/Growth-and-Marketplace/issues/25