### PR TITLE
K8s/add cluster update

### DIFF
--- a/lib/droplet_kit/mappings/kubernetes_mapping.rb
+++ b/lib/droplet_kit/mappings/kubernetes_mapping.rb
@@ -3,17 +3,17 @@ module DropletKit
     include Kartograph::DSL
     kartograph do
       mapping Kubernetes
-      root_key plural: 'kubernetes_clusters', scopes: [:read]
+      root_key plural: 'kubernetes_clusters', singular: 'kubernetes_cluster', scopes: [:read]
 
       property :id, scopes: [:read]
-      property :name, scopes: [:read]
+      property :name, scopes: [:read, :update]
       property :region, scopes: [:read]
       property :version, scopes: [:read]
       property :cluster_subnet, scopes: [:read]
       property :service_subnet, scopes: [:read]
       property :ipv4, scopes: [:read]
       property :endpoint, scopes: [:read]
-      property :tags, scopes: [:read]
+      property :tags, scopes: [:read, :update]
       property :node_pools, scopes: [:read]
     end
   end

--- a/lib/droplet_kit/resources/kubernetes_resource.rb
+++ b/lib/droplet_kit/resources/kubernetes_resource.rb
@@ -15,7 +15,10 @@ module DropletKit
       action :config, 'GET /v2/kubernetes/clusters/:cluster_id/kubeconfig' do
       end
 
-      action :update, 'PUT /v2/kubernetes/clusters/:cluster_id' do
+      action :update, 'PUT /v2/kubernetes/clusters/:id' do
+        body { |cluster| KubernetesMapping.representation_for(:update, cluster) }
+        handler(202) { |response| KubernetesMapping.extract_single(response.body, :read) }
+        handler(422) { |response| ErrorMapping.fail_with(FailedUpdate, response.body) }
       end
 
       action :upgrade, 'GET /v2/kubernetes/clusters/:cluster_id/upgrade' do

--- a/spec/fixtures/kubernetes/clusters/update.json
+++ b/spec/fixtures/kubernetes/clusters/update.json
@@ -1,0 +1,63 @@
+{
+  "kubernetes_cluster": {
+    "id": "cluster-1-id",
+    "name": "new-test-name",
+    "region": "nyc1",
+    "version": "1.12.1-do.2",
+    "cluster_subnet": "10.244.0.0/16",
+    "service_subnet": "",
+    "ipv4": "0.0.0.0",
+    "endpoint": "",
+    "tags": [
+      "new-test"
+    ],
+    "node_pools": [
+      {
+        "id": "node-pool-id",
+        "name": "node-pool-1",
+        "size": "s-1vcpu-1gb",
+        "count": 3,
+        "tags": [
+          "k8s",
+          "k8s:node-pool-id",
+          "k8s:worker",
+          "test-k8"
+        ],
+        "nodes": [
+          {
+            "id": "node-1-id",
+            "name": "node-1",
+            "status": {
+              "state": "running"
+            },
+            "created_at": "2018-11-16T20:41:44Z",
+            "updated_at": "2018-11-16T20:44:27Z"
+          },
+          {
+            "id": "node-2-id",
+            "name": "node-2",
+            "status": {
+              "state": "running"
+            },
+            "created_at": "2018-11-16T20:41:44Z",
+            "updated_at": "2018-11-16T20:44:27Z"
+          },
+          {
+            "id": "node-3-id",
+            "name": "node-3",
+            "status": {
+              "state": "running"
+            },
+            "created_at": "2018-11-16T20:41:44Z",
+            "updated_at": "2018-11-16T20:44:27Z"
+          }
+        ]
+      }
+    ],
+    "status": {
+      "state": "running"
+    },
+    "created_at": "2018-11-16T20:41:43Z",
+    "updated_at": "2018-11-16T20:44:27Z"
+  }
+}

--- a/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe DropletKit::KubernetesResource do
+  subject(:resource) { described_class.new(connection: connection) }
+  include_context 'resources'
+
+  describe '#update' do
+    let(:path) { '/v2/kubernetes/clusters' }
+    let(:new_attrs) do
+      {
+        "name" => "new-test-name",
+        "tags" => ["new-test"]
+      }
+    end
+
+    context 'for a successful update' do
+      it 'returns the created cluster' do
+        cluster = DropletKit::Kubernetes.new(new_attrs)
+
+        as_hash = DropletKit::KubernetesMapping.hash_for(:update, cluster)
+        expect(as_hash['name']).to eq(cluster.name)
+        expect(as_hash['tags']).to eq(cluster.tags)
+
+
+        as_string = DropletKit::KubernetesMapping.representation_for(:update, cluster)
+        stub_do_api(path, :put).with(body: as_string).to_return(body: api_fixture('kubernetes/clusters/update'), status: 202)
+
+        updated_cluster = resource.update(cluster)
+        expect(updated_cluster.name).to eq("new-test-name")
+        expect(updated_cluster.tags).to match_array(["new-test"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds functionality to update the name or the tags on a kubernetes cluster. Currently that is all that the public api allows to be updated.

url wrapped: `PUT /v2/kubernetes/clusters/{:cluster_id}`

closes issue: https://github.internal.digitalocean.com/digitalocean/Growth-and-Marketplace/issues/31