### PR TITLE
add wrapper for kubeconfig

### DIFF
--- a/lib/droplet_kit/resources/kubernetes_resource.rb
+++ b/lib/droplet_kit/resources/kubernetes_resource.rb
@@ -12,7 +12,8 @@ module DropletKit
       action :create, 'POST /v2/kubernetes/clusters' do
       end
 
-      action :config, 'GET /v2/kubernetes/clusters/:cluster_id/kubeconfig' do
+      action :config, 'GET /v2/kubernetes/clusters/:id/kubeconfig' do
+        handler(200) { |response| response.body }
       end
 
       action :update, 'PUT /v2/kubernetes/clusters/:cluster_id' do

--- a/spec/fixtures/kubernetes/clusters/kubeconfig.txt
+++ b/spec/fixtures/kubernetes/clusters/kubeconfig.txt
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: authoritydata
+    server: fake.server.do.com
+  name: do-nyc1-k8s-is-cool
+contexts:
+- context:
+    cluster: do-nyc1-k8s-is-cool
+    user: do-nyc1-k8s-is-cool-admin
+  name: do-nyc1-k8s-is-cool
+current-context: do-nyc1-k8s-is-cool
+kind: Config
+preferences: {}
+users:
+- name: do-nyc1-k8s-is-cool-admin
+  user:
+    client-certificate-data: certificate-data=
+    client-key-data: data-key=
+

--- a/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/kubernetes_resource_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe DropletKit::KubernetesResource do
+  subject(:resource) { described_class.new(connection: connection) }
+  include_context 'resources'
+
+  describe '#config' do
+    it 'returns a yaml string kubeconfig' do
+      response = Pathname.new('./spec/fixtures/kubernetes/clusters/kubeconfig.txt').read
+
+      stub_do_api('/v2/kubernetes/clusters/1/kubeconfig', :get).to_return(body: response)
+
+      config = resource.config(id: '1')
+
+      expect(config).to be_kind_of(String)
+
+      parsed_config = YAML.load(config)
+      expect(parsed_config.keys).to match_array(["apiVersion", "clusters", "contexts", "current-context", "kind", "preferences", "users"])
+    end
+  end
+end


### PR DESCRIPTION
add the functionality to return the kubeconfig for a cluster

currently this just returns a yaml config as a string. I think that the user will be able to then YAML.load the string if they want to convert it further into ruby land.

endpoint: `/v2/kubernetes/clusters/{cluster_id}/kubeconfig`

closes issue: https://github.internal.digitalocean.com/digitalocean/Growth-and-Marketplace/issues/27