### PR TITLE
Only ship the required libraries in the gem artifact

### DIFF
--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -13,9 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/digitalocean/droplet_kit"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = %w{LICENSE.txt README.md} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 2.0.0'


### PR DESCRIPTION
This skips the dev and test deps in the gem artifact and ships a more
mimimal set. This is pretty common in ruby gems and it's something that
Amazon and Microsoft do for their cloud API gems. This drops the
compressed gem size from 56k to 24k and the on disk size from 1.2 megs
to 483k.

Signed-off-by: Tim Smith <tsmith@chef.io>