### PR TITLE
Bump version to 3.0.1 for api_url in client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 3.0.1
+* #184 Add client override for API URL - @leprasmurf
+
 ### Version 3.0.0
 * #180 Add support for VPC - @viola
 

--- a/lib/droplet_kit/version.rb
+++ b/lib/droplet_kit/version.rb
@@ -1,3 +1,3 @@
 module DropletKit
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end


### PR DESCRIPTION
PR #184 adds support for overriding the default API URL in the client initialization.