### PR TITLE
Bump version to 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 3.0.2
+* noop - yanked 3.0.1
+
 ### Version 3.0.1
 * #184 Add client override for API URL - @leprasmurf
 

--- a/lib/droplet_kit/version.rb
+++ b/lib/droplet_kit/version.rb
@@ -1,3 +1,3 @@
 module DropletKit
-  VERSION = "3.0.1"
+  VERSION = "3.0.2"
 end


### PR DESCRIPTION
Made a mistake with the deploy and invalidated 3.0.1 on rubygems.org.  This bump is a noop.