### PR TITLE
DOKS cluster auto-upgrade fields

### DIFF
--- a/lib/droplet_kit.rb
+++ b/lib/droplet_kit.rb
@@ -116,6 +116,7 @@ module DropletKit
   autoload :FirewallPendingChangeMapping, 'droplet_kit/mappings/firewall_pending_change_mapping'
   autoload :CDNMapping, 'droplet_kit/mappings/cdn_mapping'
   autoload :KubernetesClusterMapping, 'droplet_kit/mappings/kubernetes_cluster_mapping'
+  autoload :KubernetesMaintenancePolicyMapping, 'droplet_kit/mappings/kubernetes_maintenance_policy_mapping'
   autoload :KubernetesNodePoolMapping, 'droplet_kit/mappings/kubernetes_node_pool_mapping'
   autoload :KubernetesNodeMapping, 'droplet_kit/mappings/kubernetes_node_mapping'
   autoload :KubernetesOptionsMapping, 'droplet_kit/mappings/kubernetes_options_mapping'

--- a/lib/droplet_kit/mappings/kubernetes_cluster_mapping.rb
+++ b/lib/droplet_kit/mappings/kubernetes_cluster_mapping.rb
@@ -9,11 +9,13 @@ module DropletKit
       property :name, scopes: [:read, :update, :create]
       property :region, scopes: [:read, :create]
       property :version, scopes: [:read, :create]
+      property :auto_upgrade, scopes: [:read, :update, :create]
       property :cluster_subnet, scopes: [:read]
       property :service_subnet, scopes: [:read]
       property :ipv4, scopes: [:read]
       property :endpoint, scopes: [:read]
       property :tags, scopes: [:read, :update, :create]
+      property :maintenance_policy, scopes: [:read, :update, :create]
       property :node_pools, scopes: [:read, :create]
       property :vpc_uuid, scopes: [:read, :create]
     end

--- a/lib/droplet_kit/mappings/kubernetes_maintenance_policy_mapping.rb
+++ b/lib/droplet_kit/mappings/kubernetes_maintenance_policy_mapping.rb
@@ -1,0 +1,12 @@
+module DropletKit
+  class KubernetesMaintenancePolicyMapping
+    include Kartograph::DSL
+    kartograph do
+      mapping KubernetesMaintenancePolicyMapping
+
+      property :id, scopes: [:read]
+      property :name, scopes: [:read]
+    end
+  end
+end
+

--- a/lib/droplet_kit/models/kubernetes_cluster.rb
+++ b/lib/droplet_kit/models/kubernetes_cluster.rb
@@ -1,6 +1,6 @@
 module DropletKit
   class KubernetesCluster < BaseModel
-    [:id, :name, :region, :version, :cluster_subnet, :service_subnet, :ipv4, :endpoint, :tags, :node_pools, :vpc_uuid].each do |key|
+    [:id, :name, :region, :version, :auto_upgrade, :cluster_subnet, :service_subnet, :ipv4, :endpoint, :tags, :maintenance_policy, :node_pools, :vpc_uuid].each do |key|
       attribute(key)
     end
   end

--- a/lib/droplet_kit/models/kubernetes_maintenance_policy.rb
+++ b/lib/droplet_kit/models/kubernetes_maintenance_policy.rb
@@ -1,0 +1,6 @@
+module DropletKit
+  class KubernetesMaintenancePolicy < BaseModel
+    attribute :start_time
+    attribute :day
+  end
+end

--- a/spec/fixtures/kubernetes/clusters/create.json
+++ b/spec/fixtures/kubernetes/clusters/create.json
@@ -4,6 +4,7 @@
     "name": "test-cluster",
     "region": "nyc1",
     "version": "1.12.1-do.2",
+    "auto_upgrade": true,
     "cluster_subnet": "10.244.0.0/16",
     "service_subnet": "",
     "ipv4": "0.0.0.0",
@@ -13,6 +14,10 @@
       "k8s",
       "k8s:cluster-1-id"
     ],
+    "maintenance_policy": {
+      "start_time": "15:00",
+      "day": "any"
+    },
     "node_pools": [
       {
         "id": "node-pool-id",

--- a/spec/fixtures/kubernetes/clusters/find.json
+++ b/spec/fixtures/kubernetes/clusters/find.json
@@ -4,6 +4,7 @@
     "name": "test-cluster",
     "region": "nyc1",
     "version": "1.12.1-do.2",
+    "auto_upgrade": true,
     "cluster_subnet": "10.244.0.0/16",
     "service_subnet": "",
     "ipv4": "0.0.0.0",
@@ -13,6 +14,10 @@
       "k8s",
       "k8s:cluster-1-id"
     ],
+    "maintenance_policy": {
+      "start_time": "15:00",
+      "day": "any"
+    },
     "node_pools": [
       {
         "id": "node-pool-id",

--- a/spec/fixtures/kubernetes/clusters/update.json
+++ b/spec/fixtures/kubernetes/clusters/update.json
@@ -4,6 +4,7 @@
     "name": "new-test-name",
     "region": "nyc1",
     "version": "1.12.1-do.2",
+    "auto_upgrade": true,
     "cluster_subnet": "10.244.0.0/16",
     "service_subnet": "",
     "ipv4": "0.0.0.0",
@@ -11,6 +12,10 @@
     "tags": [
       "new-test"
     ],
+    "maintenance_policy": {
+      "start_time": "12:00",
+      "day": "Tuesday"
+    },
     "node_pools": [
       {
         "id": "node-pool-id",


### PR DESCRIPTION
Add Kubernetes cluster `auto_upgrade` and `maintenance_policy` fields.

```ruby
require 'droplet_kit'

client = DropletKit::Client.new(access_token: 'REDACTED')

cluster = client.kubernetes_clusters.create(DropletKit::KubernetesCluster.new(
    name: 'ruby2',
    region: 'sfo2',
    version: '1.15',
    tags: ['test'],
    auto_upgrade: true,
    maintenance_policy: {
        start_time: '10:00',
        day: 'any'
    },
    node_pools: [
        {
            name: 'ruby',
            size: 's-1vcpu-2gb',
            count: 2,
            tags: ['test']
        }
    ]
))

client.kubernetes_clusters.update(DropletKit::KubernetesCluster.new(
    tags: ['test', 'foo'],
    maintenance_policy: {
        start_time: '16:00',
        day: 'Monday'
    }
), id: cluster.id)

```