### PR TITLE
Drop ActiveSupport as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,5 @@ rvm:
   - 2.5
   - 2.6
 
-matrix:
-  exclude:
-    - rvm: 2.0
-      env: ACTIVESUPPORT_VERSION=5
-    - rvm: 2.1
-      env: ACTIVESUPPORT_VERSION=5
-
-env:
-  - ACTIVESUPPORT_VERSION=3
-  - ACTIVESUPPORT_VERSION=4
-  - ACTIVESUPPORT_VERSION=5
-
 script:
   - bundle exec rspec ./spec

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,3 @@ source 'https://rubygems.org'
 gem 'simplecov'
 # Specify your gem's dependencies in droplet_kit.gemspec
 gemspec
-
-version = case (ENV['ACTIVESUPPORT_VERSION'] || '5')
-          when '5'
-            '>= 5.0.0.beta3'
-          when '4'
-            '~> 4.0'
-          when '3'
-            '~> 3.1'
-          end
-gem 'activesupport', version

--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0.3'
   spec.add_dependency "resource_kit", '~> 0.1.5'
   spec.add_dependency "kartograph", '~> 0.2.3'
-  spec.add_dependency "activesupport", '> 3.0', '< 6'
   spec.add_dependency "faraday", '~> 0.15'
 
   spec.add_development_dependency "bundler", ">= 1.11.0"

--- a/lib/droplet_kit.rb
+++ b/lib/droplet_kit.rb
@@ -1,5 +1,4 @@
 require 'droplet_kit/version'
-require 'active_support/all'
 require 'resource_kit'
 require 'kartograph'
 

--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'droplet_kit/utils'
 
 module DropletKit
   class Client
@@ -9,11 +10,12 @@ module DropletKit
     attr_reader :access_token, :api_url, :open_timeout, :timeout, :user_agent
 
     def initialize(options = {})
-      @access_token = options.with_indifferent_access[:access_token]
-      @api_url      = options.with_indifferent_access[:api_url] || DIGITALOCEAN_API
-      @open_timeout = options.with_indifferent_access[:open_timeout] || DEFAULT_OPEN_TIMEOUT
-      @timeout      = options.with_indifferent_access[:timeout] || DEFAULT_TIMEOUT
-      @user_agent   = options.with_indifferent_access[:user_agent]
+      options = DropletKit::Utils.transform_keys(options, &:to_sym)
+      @access_token = options[:access_token]
+      @api_url      = options[:api_url] || DIGITALOCEAN_API
+      @open_timeout = options[:open_timeout] || DEFAULT_OPEN_TIMEOUT
+      @timeout      = options[:timeout] || DEFAULT_TIMEOUT
+      @user_agent   = options[:user_agent]
     end
 
     def connection

--- a/lib/droplet_kit/models/base_model.rb
+++ b/lib/droplet_kit/models/base_model.rb
@@ -1,4 +1,5 @@
 require 'virtus'
+require 'droplet_kit/utils'
 
 module DropletKit
   class BaseModel
@@ -18,7 +19,7 @@ module DropletKit
     end
 
     def collection_name
-      self.class.name.split('::').last.underscore
+      DropletKit::Utils.underscore self.class.name.split('::').last
     end
 
     def identifier
@@ -36,7 +37,7 @@ module DropletKit
       return true if UNSUPPORTED_COLLECTIONS.include?(collection)
 
       begin
-        "DropletKit::#{collection.camelize}".constantize
+        const_get "DropletKit::#{DropletKit::Utils.camelize(collection)}"
       rescue NameError
         return false
       end
@@ -53,7 +54,7 @@ module DropletKit
 
       return nil if UNSUPPORTED_COLLECTIONS.include?(collection)
 
-      klass = "DropletKit::#{collection.camelize}".constantize
+      klass = const_get("DropletKit::#{DropletKit::Utils.camelize(collection)}")
       klass.from_identifier(identifier)
     end
 

--- a/lib/droplet_kit/models/project_assignment.rb
+++ b/lib/droplet_kit/models/project_assignment.rb
@@ -5,7 +5,9 @@ module DropletKit
     attribute :links
 
     def self_link
-      links.try(:myself)
+      return unless links
+
+      links.myself
     end
 
     def to_model

--- a/lib/droplet_kit/utils.rb
+++ b/lib/droplet_kit/utils.rb
@@ -1,0 +1,33 @@
+module DropletKit
+  module Utils
+    def self.camelize(term)
+      string = term.to_s
+      string.sub!(/^[a-z\d]*/, &:capitalize)
+      string.gsub!(%r{(?:_|(/))([a-z\d]*)}i) { $2.capitalize }
+      string.gsub!('/'.freeze, '::'.freeze)
+      string
+    end
+
+    def self.underscore(term)
+      return term unless /[A-Z-]|::/ =~ term
+
+      word = term.to_s.gsub('::'.freeze, '/'.freeze)
+      word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2'.freeze)
+      word.gsub!(/([a-z\d])([A-Z])/, '\1_\2'.freeze)
+      word.tr!('-'.freeze, '_'.freeze)
+      word.downcase!
+      word
+    end
+
+    def self.transform_keys(hash, &block)
+      return hash.transform_keys(&block) if hash.respond_to?(:transform_keys)
+      return to_enum(__caller__) unless block_given?
+
+      {}.tap do |result|
+        hash.each do |key, value|
+          result[block.call(key)] = value
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/droplet_kit/models/base_model_spec.rb
+++ b/spec/lib/droplet_kit/models/base_model_spec.rb
@@ -10,6 +10,26 @@ RSpec.describe DropletKit::BaseModel do
     end
   end
 
+  describe '.valid_urn?' do
+    it 'is true when there is a constant matching the collection' do
+      urn = 'do:droplet:123456'
+
+      expect(described_class.valid_urn?(urn)).to be true
+    end
+
+    it 'is true when it is an unsupported collection' do
+      urn = 'do:space:234567'
+
+      expect(described_class.valid_urn?(urn)).to be true
+    end
+
+    it 'is false when there is no constant matching the name' do
+      urn = 'do:whale:345678'
+
+      expect(described_class.valid_urn?(urn)).to be false
+    end
+  end
+
   describe '#inspect' do
     it 'returns the information about the current user' do
       instance = resource.new(droplet_limit: 5)

--- a/spec/lib/droplet_kit/models/droplet_spec.rb
+++ b/spec/lib/droplet_kit/models/droplet_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe DropletKit::Droplet do
   let(:droplet_fixture) { api_fixture('droplets/find') }
   let(:droplet) { DropletKit::DropletMapping.extract_single(droplet_fixture, :read) }
 
+  describe '#urn' do
+    it 'correctly underscores the collection' do
+      expect(droplet.urn).to eq 'do:droplet:19'
+    end
+  end
+
   describe '#public_ip' do
     it 'returns the public IP for ipv4' do
       expect(droplet.public_ip).to eq('127.0.0.19')

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,22 @@
+module DropletKitHelpers
+  BLANK_RE = /\A[[:space:]]*\z/
+
+  def self.presence(object)
+    case object
+    when String then !object.empty? || BLANK_RE !~ object
+    else !!object
+    end
+  end
+end
+
+RSpec::Matchers.define :be_present do
+  match do |actual|
+    DropletKitHelpers.presence(actual)
+  end
+end
+
+RSpec::Matchers.define :be_blank do
+  match do |actual|
+    !DropletKitHelpers.presence(actual)
+  end
+end


### PR DESCRIPTION
Looking through the history of the respository, it seems that keeping
up-to-date with releases of Rails and ActiveSupport is a burden because
there's a lack of trust that new versions of ActiveSupport won't break
compatibility.

Since the usage of ActiveSupport is so minimal in the library and the
test suite, it seems like it would be better to drop it as a dependency
so you don't have that burden anymore.

This has the happy effect that you no longer have to worry about Rails
compatibility and you aren't bringing along a giant library of tools
just for a simple API gem.