### PR TITLE
Allowing :filesystem_type on a Volume

### DIFF
--- a/lib/droplet_kit/mappings/volume_mapping.rb
+++ b/lib/droplet_kit/mappings/volume_mapping.rb
@@ -16,7 +16,8 @@ module DropletKit
 
       property :region, scopes: [:create]
       property :snapshot_id, scopes: [:create]
-      property :filesystem_type, scopes: [:create]
+      property :filesystem_type, scopes: [:read, :create]
+      property :filesystem_label, scopes: [:read, :create]
     end
   end
 end

--- a/lib/droplet_kit/mappings/volume_mapping.rb
+++ b/lib/droplet_kit/mappings/volume_mapping.rb
@@ -16,6 +16,7 @@ module DropletKit
 
       property :region, scopes: [:create]
       property :snapshot_id, scopes: [:create]
+      property :filesystem_type, scopes: [:create]
     end
   end
 end

--- a/lib/droplet_kit/models/volume.rb
+++ b/lib/droplet_kit/models/volume.rb
@@ -8,6 +8,7 @@ module DropletKit
     attribute :size_gigabytes
     attribute :created_at
     attribute :filesystem_type
+    attribute :filesystem_label
 
     # Used for creates
     attribute :snapshot_id

--- a/lib/droplet_kit/models/volume.rb
+++ b/lib/droplet_kit/models/volume.rb
@@ -7,6 +7,7 @@ module DropletKit
     attribute :description
     attribute :size_gigabytes
     attribute :created_at
+    attribute :filesystem_type
 
     # Used for creates
     attribute :snapshot_id

--- a/lib/droplet_kit/resources/volume_resource.rb
+++ b/lib/droplet_kit/resources/volume_resource.rb
@@ -9,7 +9,7 @@ module DropletKit
       end
 
       action :create, 'POST /v2/volumes' do
-        body { |object| binding.pry; VolumeMapping.representation_for(:create, object) }
+        body { |object| VolumeMapping.representation_for(:create, object) }
         handler(201) { |response| VolumeMapping.extract_single(response.body, :read) }
         handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
       end

--- a/lib/droplet_kit/resources/volume_resource.rb
+++ b/lib/droplet_kit/resources/volume_resource.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module DropletKit
   class VolumeResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/volume_resource.rb
+++ b/lib/droplet_kit/resources/volume_resource.rb
@@ -1,3 +1,4 @@
+require 'pry'
 module DropletKit
   class VolumeResource < ResourceKit::Resource
     include ErrorHandlingResourcable
@@ -9,7 +10,7 @@ module DropletKit
       end
 
       action :create, 'POST /v2/volumes' do
-        body { |object| VolumeMapping.representation_for(:create, object) }
+        body { |object| binding.pry; VolumeMapping.representation_for(:create, object) }
         handler(201) { |response| VolumeMapping.extract_single(response.body, :read) }
         handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
       end

--- a/spec/fixtures/volumes/all.json
+++ b/spec/fixtures/volumes/all.json
@@ -30,7 +30,9 @@
       "name": "Example",
       "description": "Block store for examples",
       "size_gigabytes": 10,
-      "created_at": "2016-03-02T17:00:49Z"
+      "created_at": "2016-03-02T17:00:49Z",
+      "filesystem_type": "ext4",
+      "filesystem_label": "archive"
     }
   ],
   "links": {

--- a/spec/fixtures/volumes/create.json
+++ b/spec/fixtures/volumes/create.json
@@ -29,6 +29,8 @@
     "name": "Example",
     "description": "Block store for examples",
     "size_gigabytes": 10,
-    "created_at": "2016-03-02T17:00:49Z"
+    "created_at": "2016-03-02T17:00:49Z",
+    "filesystem_type": "ext4",
+    "filesystem_label": "archive"
   }
 }

--- a/spec/fixtures/volumes/find.json
+++ b/spec/fixtures/volumes/find.json
@@ -29,6 +29,8 @@
     "name": "Example",
     "description": "Block store for examples",
     "size_gigabytes": 10,
-    "created_at": "2016-03-02T17:00:49Z"
+    "created_at": "2016-03-02T17:00:49Z",
+    "filesystem_type": "ext4",
+    "filesystem_label": "archive"
   }
 }

--- a/spec/lib/droplet_kit/resources/volume_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/volume_resource_spec.rb
@@ -79,6 +79,40 @@ RSpec.describe DropletKit::VolumeResource do
       end
     end
 
+    context 'with a filesystem_type' do 
+      it 'allows the filesystem_type' do 
+        volume = DropletKit::Volume.new(
+          size_gigabytes: 10,
+          name: "Example",
+          description: "Block store for examples",
+          filesystem_type: 'ext4'
+        )
+
+        as_string = DropletKit::VolumeMapping.representation_for(:create, volume)
+        stub_do_api(path, :post).with(body: as_string).to_return(body: api_fixture('volumes/create'), status: 201)
+        created_volume = resource.create(volume)
+
+        expect(created_volume).to match_volume_fixture
+      end
+    end
+
+    context 'with a filesystem_label' do
+      it 'allows the filesystem_label' do 
+        volume = DropletKit::Volume.new(
+          size_gigabytes: 10,
+          name: "Example",
+          description: "Block store for examples",
+          filesystem_label: 'archive'
+        )
+
+        as_string = DropletKit::VolumeMapping.representation_for(:create, volume)
+        stub_do_api(path, :post).with(body: as_string).to_return(body: api_fixture('volumes/create'), status: 201)
+        created_volume = resource.create(volume)
+
+        expect(created_volume).to match_volume_fixture
+      end
+    end
+
     it_behaves_like 'an action that handles invalid parameters' do
       let(:action) { 'create' }
       let(:arguments) { DropletKit::Volume.new }

--- a/spec/lib/droplet_kit/resources/volume_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/volume_resource_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe DropletKit::VolumeResource do
       expect(volume.description).to eq("Block store for examples")
       expect(volume.size_gigabytes).to eq(10)
       expect(volume.created_at).to eq("2016-03-02T17:00:49Z")
+      expect(volume.filesystem_type).to eq("ext4")
+      expect(volume.filesystem_label).to eq("archive")
     end
   end
 
@@ -79,8 +81,8 @@ RSpec.describe DropletKit::VolumeResource do
       end
     end
 
-    context 'with a filesystem_type' do 
-      it 'allows the filesystem_type' do 
+    context 'with a filesystem_type' do
+      it 'allows the filesystem_type' do
         volume = DropletKit::Volume.new(
           size_gigabytes: 10,
           name: "Example",
@@ -97,7 +99,7 @@ RSpec.describe DropletKit::VolumeResource do
     end
 
     context 'with a filesystem_label' do
-      it 'allows the filesystem_label' do 
+      it 'allows the filesystem_label' do
         volume = DropletKit::Volume.new(
           size_gigabytes: 10,
           name: "Example",


### PR DESCRIPTION
Resolves #198

The gem allows for setting this but per the documentation I don't believe it's actively returned by the API.