### PR TITLE
Add container registry support

### DIFF
--- a/lib/droplet_kit.rb
+++ b/lib/droplet_kit.rb
@@ -7,6 +7,7 @@ module DropletKit
 
   # Models
   autoload :BaseModel, 'droplet_kit/models/base_model'
+  autoload :ContainerRegistry, 'droplet_kit/models/container_registry'
   autoload :Droplet, 'droplet_kit/models/droplet'
   autoload :Region, 'droplet_kit/models/region'
   autoload :Image, 'droplet_kit/models/image'
@@ -52,6 +53,7 @@ module DropletKit
   # Resources
   autoload :DropletResource, 'droplet_kit/resources/droplet_resource'
   autoload :ActionResource, 'droplet_kit/resources/action_resource'
+  autoload :ContainerRegistryResource, 'droplet_kit/resources/container_registry_resource'
   autoload :DomainResource, 'droplet_kit/resources/domain_resource'
   autoload :DomainRecordResource, 'droplet_kit/resources/domain_record_resource'
   autoload :DropletActionResource, 'droplet_kit/resources/droplet_action_resource'
@@ -79,6 +81,7 @@ module DropletKit
 
   # JSON Maps
   autoload :DropletMapping, 'droplet_kit/mappings/droplet_mapping'
+  autoload :ContainerRegistryMapping, 'droplet_kit/mappings/container_registry_mapping'
   autoload :ImageMapping, 'droplet_kit/mappings/image_mapping'
   autoload :RegionMapping, 'droplet_kit/mappings/region_mapping'
   autoload :SizeMapping, 'droplet_kit/mappings/size_mapping'

--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -31,6 +31,7 @@ module DropletKit
         actions: ActionResource,
         cdns: CDNResource,
         certificates: CertificateResource,
+        container_registry: ContainerRegistryResource,
         droplets: DropletResource,
         kubernetes_clusters: KubernetesClusterResource,
         kubernetes_options: KubernetesOptionsResource,

--- a/lib/droplet_kit/mappings/container_registry_mapping.rb
+++ b/lib/droplet_kit/mappings/container_registry_mapping.rb
@@ -1,0 +1,11 @@
+module DropletKit
+  class ContainerRegistryMapping
+    include Kartograph::DSL
+    kartograph do
+      mapping ContainerRegistry
+      root_key singular: 'registry', scopes: [:read]
+
+      property :name, scopes: [:read, :create]
+    end
+  end
+end

--- a/lib/droplet_kit/models/container_registry.rb
+++ b/lib/droplet_kit/models/container_registry.rb
@@ -1,0 +1,7 @@
+module DropletKit
+  class ContainerRegistry < BaseModel
+    [:name].each do |key|
+      attribute(key)
+    end
+  end
+end

--- a/lib/droplet_kit/resources/container_registry_resource.rb
+++ b/lib/droplet_kit/resources/container_registry_resource.rb
@@ -1,0 +1,26 @@
+module DropletKit
+    class ContainerRegistryResource < ResourceKit::Resource
+      include ErrorHandlingResourcable
+  
+      resources do
+        action :get, 'GET /v2/registry' do
+          handler(200) { |response| ContainerRegistryMapping.extract_single(response.body, :read) }
+        end
+  
+        action :create, 'POST /v2/registry' do
+          body { |object| ContainerRegistryMapping.representation_for(:create, object) }
+          handler(201) { |response, registry| ContainerRegistryMapping.extract_into_object(registry, response.body, :read) }
+          handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
+        end
+  
+        action :delete, 'DELETE /v2/registry' do
+          handler(204) { |response| true }
+        end
+
+        action :docker_credentials, 'GET /v2/registry/docker-credentials' do
+          handler(200) { |response| response.body }
+        end
+      end
+    end
+end
+  

--- a/spec/fixtures/container_registry/create.json
+++ b/spec/fixtures/container_registry/create.json
@@ -1,0 +1,5 @@
+{
+  "registry": {
+    "name": "foobar"
+  }
+}

--- a/spec/fixtures/container_registry/docker-credentials.json
+++ b/spec/fixtures/container_registry/docker-credentials.json
@@ -1,0 +1,1 @@
+{"auths":{"registry.digitalocean.com":{"auth":"secret"}}}

--- a/spec/fixtures/container_registry/get.json
+++ b/spec/fixtures/container_registry/get.json
@@ -1,0 +1,5 @@
+{
+  "registry": {
+    "name": "foobar"
+  }
+}

--- a/spec/lib/droplet_kit/resources/container_registry_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/container_registry_resource_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+RSpec.describe DropletKit::ContainerRegistryResource do
+  subject(:resource) { described_class.new(connection: connection) }
+  include_context 'resources'
+
+  describe '#get' do
+    it 'returns a registry' do
+      stub_do_api('/v2/registry', :get).to_return(body: api_fixture('container_registry/get'))
+      registry = resource.get
+      expect(registry).to be_kind_of(DropletKit::ContainerRegistry)
+
+      expect(registry.name).to eq("foobar")
+    end
+
+    it_behaves_like 'resource that handles common errors' do
+      let(:path) { '/v2/registry' }
+      let(:method) { :get }
+      let(:action) { :get }
+    end
+  end
+
+  describe '#create' do
+    let(:path) { '/v2/registry' }
+    let(:new_attrs) do
+      {
+        "name" => "foobar"
+      }
+    end
+
+    context 'for a successful create' do
+      it 'returns the created registry' do
+        registry = DropletKit::ContainerRegistry.new(new_attrs)
+
+        as_hash = DropletKit::ContainerRegistryMapping.hash_for(:create, registry)
+        expect(as_hash['name']).to eq(registry.name)
+
+
+        as_string = DropletKit::ContainerRegistryMapping.representation_for(:create, registry)
+        stub_do_api(path, :post).with(body: as_string).to_return(body: api_fixture('container_registry/create'), status: 201)
+        created_registry = resource.create(registry)
+        expect(registry.name).to eq("foobar")
+      end
+
+      it 'reuses the same object' do
+        registry = DropletKit::ContainerRegistry.new(new_attrs)
+
+        json = DropletKit::ContainerRegistryMapping.representation_for(:create, registry)
+        stub_do_api(path, :post).with(body: json).to_return(body: api_fixture('container_registry/create'), status: 201)
+        created_registry = resource.create(registry)
+        expect(created_registry).to be registry
+      end
+    end
+
+    it_behaves_like 'an action that handles invalid parameters' do
+      let(:action) { 'create' }
+      let(:arguments) { DropletKit::ContainerRegistry.new }
+    end
+  end
+
+  describe '#delete' do
+    it 'sends a delete request for a registry' do
+      request = stub_do_api('/v2/registry', :delete).to_return(status: 204)
+      response = resource.delete
+
+      expect(request).to have_been_made
+      expect(response).to eq(true)
+    end
+  end
+
+  describe '#docker-credentials' do
+    it 'returns docker credentials' do
+      response = Pathname.new('./spec/fixtures/container_registry/docker-credentials.json').read
+      stub_do_api('/v2/registry/docker-credentials', :get).to_return(body: response)
+      creds = resource.docker_credentials
+  
+      expect(creds).to be_kind_of(String)
+      parsed_creds = JSON.load(creds)
+      expect(parsed_creds).to eq(
+        'auths' => {
+          'registry.digitalocean.com' => {
+            'auth' => 'secret'
+          }
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
```
client = DropletKit::Client.new(access_token: 'REDACTED')

registry = DropletKit::ContainerRegistry.new(name: 'snormore')
client.container_registry.create(registry)

registry = client.container_registry.get
puts registry

creds = client.container_registry.docker_credentials
puts creds
```