### PR TITLE
Prepare to release v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 3.4.0
+- #212 Fix awkward sentence - @bentranter
+- #211 Add partial support for managed databases - @bentranter
+
 ### Version 3.3.1
 * #209 loadbalancer: default fields to false, not null - @zachgersh
 

--- a/lib/droplet_kit/version.rb
+++ b/lib/droplet_kit/version.rb
@@ -1,3 +1,3 @@
 module DropletKit
-  VERSION = "3.3.1"
+  VERSION = "3.4.0"
 end


### PR DESCRIPTION
Prepares to release v3.4.0, since the change freeze has now been lifted.