### PR TITLE
Change create_cluster handler to 201 IAW DO::Database docs

### DIFF
--- a/lib/droplet_kit/resources/database_resource.rb
+++ b/lib/droplet_kit/resources/database_resource.rb
@@ -13,7 +13,7 @@ module DropletKit
 
       action :create_cluster, 'POST /v2/databases' do
         body { |object| DatabaseClusterMapping.representation_for(:create, object) }
-        handler(202) { |response, database| DatabaseClusterMapping.extract_into_object(database, response.body, :read) }
+        handler(201) { |response, database| DatabaseClusterMapping.extract_into_object(database, response.body, :read) }
         handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
       end
 

--- a/spec/lib/droplet_kit/resources/database_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/database_resource_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe DropletKit::DatabaseResource do
       expect(as_hash['tags']).to eq(database_cluster.tags)
 
       json_body = DropletKit::DatabaseClusterMapping.representation_for(:create, database_cluster)
-      stub_do_api('/v2/databases', :post).with(body: json_body).to_return(body: api_fixture('databases/create_cluster'), status: 202)
+      stub_do_api('/v2/databases', :post).with(body: json_body).to_return(body: api_fixture('databases/create_cluster'), status: 201)
 
       created_database_cluster = resource.create_cluster(database_cluster)
       expect(created_database_cluster).to be_kind_of(DropletKit::DatabaseCluster)


### PR DESCRIPTION
- Change create_cluster handler to 201

Currently create_cluster returns nil because it's looking for 202.

https://developers.digitalocean.com/documentation/v2/#create-a-new-database-cluster shows 201 as well.  I checked it out and 201 works great on my fork.