### PR TITLE
make sure cookie_ttl_seconds always int

### DIFF
--- a/lib/droplet_kit/models/load_balancer.rb
+++ b/lib/droplet_kit/models/load_balancer.rb
@@ -11,7 +11,7 @@ module DropletKit
     attribute :redirect_http_to_https, Boolean, :default => false
     attribute :enable_proxy_protocol, Boolean, :default => false
     attribute :droplet_ids
-    attribute :sticky_sessions
+    attribute :sticky_sessions, StickySession
     attribute :health_check
     attribute :forwarding_rules
     attribute :vpc_uuid

--- a/lib/droplet_kit/models/sticky_session.rb
+++ b/lib/droplet_kit/models/sticky_session.rb
@@ -1,7 +1,7 @@
 module DropletKit
   class StickySession < BaseModel
-    attribute :type
-    attribute :cookie_name
-    attribute :cookie_ttl_seconds
+    attribute :type, String
+    attribute :cookie_name, String
+    attribute :cookie_ttl_seconds, Integer
   end
 end

--- a/spec/lib/droplet_kit/models/loadbalancer_spec.rb
+++ b/spec/lib/droplet_kit/models/loadbalancer_spec.rb
@@ -1,27 +1,33 @@
 require 'spec_helper'
 
 RSpec.describe DropletKit::LoadBalancer do
-  let(:lb) { DropletKit::LoadBalancer.new }
+  let(:lb) { DropletKit::LoadBalancer.new(:sticky_sessions => {:cookie_ttl_seconds => "500"}) }
 
-  describe 'default' do
-    it 'sets redirect_http_to_https to false' do
+  describe 'redirect_http_to_https' do
+    it 'defaults to false' do
       expect(lb.redirect_http_to_https).to be false
     end
 
-    it 'sets enable_proxy_protocol to false' do
-      expect(lb.enable_proxy_protocol).to be false
-    end
-  end
-
-  describe 'setting' do
-    it 'sets redirect_http_to_https to false' do
+    it 'can be set to true' do
       lb.redirect_http_to_https = true
       expect(lb.redirect_http_to_https).to be true
     end
+  end
 
-    it 'sets enable_proxy_protocol to false' do
+  describe 'enable_proxy_protocol' do
+    it 'defaults to false' do
+      expect(lb.enable_proxy_protocol).to be false
+    end
+
+    it 'can be set to true' do
       lb.enable_proxy_protocol = true
       expect(lb.enable_proxy_protocol).to be true
+    end
+  end
+
+  describe 'sticky_sessions' do
+    it 'cookie_ttl_seconds is never a string' do
+      expect(lb.sticky_sessions.cookie_ttl_seconds).to eq 500
     end
   end
 end


### PR DESCRIPTION
Goal here is to always make sure `cookie_ttl_seconds` ends up as an int from droplet_kits perspective when using this model.

I rewrote the test I had added previously, the describe blocks made absolutely no sense whatsoever.