### PR TITLE
Fix PaginatedResource's "last?" method

### DIFF
--- a/lib/droplet_kit/paginated_resource.rb
+++ b/lib/droplet_kit/paginated_resource.rb
@@ -44,6 +44,7 @@ module DropletKit
     end
 
     def last?
+      return true if self.total.nil?
       @current_page == total_pages || self.total.zero?
     end
 

--- a/spec/lib/droplet_kit/paginated_resource_spec.rb
+++ b/spec/lib/droplet_kit/paginated_resource_spec.rb
@@ -90,6 +90,11 @@ RSpec.describe DropletKit::PaginatedResource do
       expect(instance.last?).to eq(true)
     end
 
+    it 'returns false on the first page of results' do
+      instance.first
+      expect(instance.last?).to eq(false)
+    end
+
     it 'returns true on the last page of results' do
       instance.each do end
       expect(instance.last?).to eq(true)

--- a/spec/lib/droplet_kit/paginated_resource_spec.rb
+++ b/spec/lib/droplet_kit/paginated_resource_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe DropletKit::PaginatedResource do
   describe '#last?' do
     let(:instance) { DropletKit::PaginatedResource.new(action, resource) }
 
-    it 'returns false when no request is made' do
+    it 'returns true when no request is made' do
       expect(instance.last?).to eq(true)
     end
 

--- a/spec/lib/droplet_kit/paginated_resource_spec.rb
+++ b/spec/lib/droplet_kit/paginated_resource_spec.rb
@@ -82,4 +82,17 @@ RSpec.describe DropletKit::PaginatedResource do
       end
     end
   end
+
+  describe '#last?' do
+    let(:instance) { DropletKit::PaginatedResource.new(action, resource) }
+
+    it 'returns false when no request is made' do
+      expect(instance.last?).to eq(true)
+    end
+
+    it 'returns true on the last page of results' do
+      instance.each do end
+      expect(instance.last?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
Closes #226

For any resource that is a `PaginatedResource` (that is, it supports the API's pagination logic), there's currently an issue where the `last?` method call fails if,
  * No request has been made, or
  * There's only a single page of results.

This PR addresses the issue by adding a `nil` check on the `total` field, so that the following `zero?` method call won't fail if the `total` is `nil`.