### PR TITLE
Downgrade required bundler version

### DIFF
--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "kartograph", '~> 0.2.3'
   spec.add_dependency "faraday", '~> 0.15'
 
-  spec.add_development_dependency "bundler", ">= 2.1.4"
+  spec.add_development_dependency "bundler", ">= 2.1.2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.9.0"
   spec.add_development_dependency "rb-readline"


### PR DESCRIPTION
Downgrades the required version of bundler from 2.1.4 to 2.1.2.

It seems that the Ruby environment that CI runs in cannot access the latest release of bundler. With that said, 2.1.2 is still very recent (it was released in December 2019), so I believe that to be an acceptable version of bundler to use for the sake of running the job to release the gem on RubyGems.

If this isn't okay, I'll reach out internally to see what we can do about getting access to the latest release of bundler in the CI environment.