### PR TITLE
FIX: Ruby 2.7 `Proc.new` deprecation warning

### DIFF
--- a/lib/droplet_kit/paginated_resource.rb
+++ b/lib/droplet_kit/paginated_resource.rb
@@ -25,7 +25,7 @@ module DropletKit
       @collection[index]
     end
 
-    def each(start = 0)
+    def each(start = 0, &block)
       # Start off with the first page if we have no idea of anything yet
       fetch_next_page if total.nil?
 
@@ -37,7 +37,7 @@ module DropletKit
       unless last?
         start = [@collection.size, start].max
         fetch_next_page
-        each(start, &Proc.new)
+        each(start, &block)
       end
 
       self


### PR DESCRIPTION
This fixes the following Ruby 2.7 deprecation warning:

```
Capturing the given block using Proc.new is deprecated; use `&block`
instead.
```

Thanks!