### PR TITLE
Prepare for release v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## unreleased
 
-- #234 Add support for enable_backend_keepalive to LBs - @anitgandhi
+### Version 3.7.0
+
+- #237 Add VPC v3 attributes - @viola
+- #234 load balancers: add new field enable_backend_keepalive - @anitgandhi
 
 ### Version 3.6.0
 

--- a/lib/droplet_kit/version.rb
+++ b/lib/droplet_kit/version.rb
@@ -1,3 +1,3 @@
 module DropletKit
-  VERSION = "3.6.0"
+  VERSION = "3.7.0"
 end


### PR DESCRIPTION
Forgot to bump the changelog and version number, so I'm doing that now.