### PR TITLE
Upgrade minimum Ruby version to 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
   - gem update bundler
 
 rvm:
-  - 2.4
   - 2.5
   - 2.6
   - 2.7

--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = %w{LICENSE.txt README.md} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'virtus', '~> 1.0.3'
   spec.add_dependency "resource_kit", '~> 0.1.5'


### PR DESCRIPTION
Upgrades the minimum Ruby version to 2.5 in the `gemspec`. For context, support for Ruby 2.4 ended March 31, 2020 – see https://www.ruby-lang.org/en/downloads/branches.

To validate that this is okay, I ran,

```
bundle install --local --verbose
```

locally, and everything appears to be fine.