### PR TITLE
Allow any Faraday version greater than 0.15

### DIFF
--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -6,7 +6,7 @@ require 'droplet_kit/version'
 Gem::Specification.new do |spec|
   spec.name          = "droplet_kit"
   spec.version       = DropletKit::VERSION
-  spec.authors       = ["Digital Ocean API/CLI team"]
+  spec.authors       = ["DigitalOcean API Engineering team"]
   spec.email         = ["devex-api-engineering@digitalocean.com"]
   spec.summary       = %q{Droplet Kit is the official Ruby library for DigitalOcean's API}
   spec.description   = %q{Droplet Kit is the official Ruby library for DigitalOcean's API}
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus', '~> 1.0.3'
   spec.add_dependency "resource_kit", '~> 0.1.5'
   spec.add_dependency "kartograph", '~> 0.2.3'
-  spec.add_dependency "faraday", '~> 0.15'
+  spec.add_dependency "faraday", '>= 0.15'
 
   spec.add_development_dependency "bundler", ">= 2.1.2"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Updates the gemspec to allow any Faraday version greater than 0.15, since Faraday 1.0 was finally released last year.

Previously, we used the pessimistic operator to only allow versions greater than or equal to 0.15 and less than 1.0. This changes that to allow any version greater than 0.15.

I've run the tests with Faraday 1.0.1, and things seems to be okay, but we'll see what CI says.

---

I also updated our team name, and fixed the spacing of "Digital Ocean" to "DigitalOcean".

If merged, this will fix #244.