### PR TITLE
Allow VPCs to be set as default

### DIFF
--- a/lib/droplet_kit/mappings/vpc_mapping.rb
+++ b/lib/droplet_kit/mappings/vpc_mapping.rb
@@ -20,6 +20,7 @@ module DropletKit
       scoped :update, :patch do
         property :name
         property :description
+        property :default
       end
 
       scoped :create do

--- a/spec/fixtures/vpcs/find_default.json
+++ b/spec/fixtures/vpcs/find_default.json
@@ -1,0 +1,13 @@
+{
+  "vpc":
+    {
+      "id":"880b7f98-f062-404d-b33c-458d545696f6",
+      "urn":"do:vpc:880b7f98-f062-404d-b33c-458d545696f6",
+      "name":"my-new-vpc-1",
+      "description":"vpc desc",
+      "ip_range":"10.108.0.0/20",
+      "region":"nyc3",
+      "created_at":"2019-03-29T21:48:40.995304079Z",
+      "default":true
+    }
+}


### PR DESCRIPTION
This PR changes the VPC update resources to allow a VPC to be set as `default` for a region.