### PR TITLE
Add ability to query a domain record resources by name and type

### DIFF
--- a/lib/droplet_kit/resources/domain_record_resource.rb
+++ b/lib/droplet_kit/resources/domain_record_resource.rb
@@ -4,7 +4,7 @@ module DropletKit
 
     resources do
       action :all, 'GET /v2/domains/:for_domain/records' do
-        query_keys :per_page, :page
+        query_keys :per_page, :page, :name, :type
         handler(200) { |response| DomainRecordMapping.extract_collection(response.body, :read) }
       end
 

--- a/spec/fixtures/domain_records/cname.json
+++ b/spec/fixtures/domain_records/cname.json
@@ -1,0 +1,17 @@
+{
+  "domain_records": [
+    {
+      "id": 1,
+      "type": "CNAME",
+      "name": "example",
+      "data": "@",
+      "priority": null,
+      "port": null,
+      "ttl": 1800,
+      "weight": null
+    }
+  ],
+  "meta": {
+    "total": 1
+  }
+}

--- a/spec/fixtures/domain_records/list_cname.json
+++ b/spec/fixtures/domain_records/list_cname.json
@@ -1,0 +1,27 @@
+{
+  "domain_records": [
+    {
+      "id": 1,
+      "type": "CNAME",
+      "name": "example",
+      "data": "@",
+      "priority": null,
+      "port": null,
+      "ttl": 1800,
+      "weight": null
+    },
+    {
+      "id": 2,
+      "type": "CNAME",
+      "name": "*.example",
+      "data": "@",
+      "priority": null,
+      "port": null,
+      "ttl": 1800,
+      "weight": null
+    }
+  ],
+  "meta": {
+    "total": 2
+  }
+}

--- a/spec/lib/droplet_kit/resources/domain_record_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/domain_record_resource_spec.rb
@@ -16,6 +16,32 @@ RSpec.describe DropletKit::DomainRecordResource do
       expect(returned_records).to eq(expected_records)
     end
 
+    it 'with queried CNAME type returns all of the CNAME domain records for a domain' do
+      response = api_fixture('domain_records/list_cname')
+      stub_do_api('/v2/domains/example.com/records', :get)
+        .with(query: hash_including({ type: 'CNAME' }))
+        .to_return(body: response)
+
+      expected_records = DropletKit::DomainRecordMapping.extract_collection(response, :read)
+      returned_records = resource.all(for_domain: 'example.com', type: 'CNAME')
+
+      expect(returned_records).to all(be_kind_of(DropletKit::DomainRecord))
+      expect(returned_records).to eq(expected_records)
+    end
+
+    it 'with queried name returns all of the domain records with the same name for a domain' do
+      response = api_fixture('domain_records/cname')
+      stub_do_api('/v2/domains/example.com/records', :get)
+        .with(query: hash_including({ name: 'example' }))
+        .to_return(body: response)
+
+      expected_records = DropletKit::DomainRecordMapping.extract_collection(response, :read)
+      returned_records = resource.all(for_domain: 'example.com', name: 'example')
+
+      expect(returned_records).to all(be_kind_of(DropletKit::DomainRecord))
+      expect(returned_records).to eq(expected_records)
+    end
+
     it_behaves_like 'a paginated index' do
       let(:fixture_path) {'domain_records/all'}
       let(:api_path) {'/v2/domains/example.com/records'}


### PR DESCRIPTION
Since the DigitalOcean API [allows](https://developers.digitalocean.com/documentation/v2/#list-all-domain-records) to filter a list of all domain records configured for a specific domain by name and type, then I decided to add this functionality to this awesome library