### PR TITLE
[DatabaseUser] Add name to create scope

### DIFF
--- a/lib/droplet_kit/mappings/database_user_mapping.rb
+++ b/lib/droplet_kit/mappings/database_user_mapping.rb
@@ -6,7 +6,7 @@ module DropletKit
       mapping DatabaseUser
       root_key singular: 'user', plural: 'users', scopes: [:read]
 
-      property :name, scopes: [:read]
+      property :name, scopes: [:read, :create]
       property :role, scopes: [:read, :create]
       property :password, scopes: [:read, :create]
     end


### PR DESCRIPTION
`DatabaseUser.name` is not currently mapped when creating a new user with `create_database_user`, leading to HTTP 422 errors as it is a [required field](https://developers.digitalocean.com/documentation/v2/#add-a-database-user).