### PR TITLE
load-balancers: add support for disable_lets_encrypt_dns_records field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 3.16.0
+
+- #266 load balancers: add new field disable_lets_encrypt_dns_records - @dikshant
+
 ## Version 3.15.0
 
 - #283 - @sunny-b - K8s: add ha and supported_features fields

--- a/lib/droplet_kit/mappings/load_balancer_mapping.rb
+++ b/lib/droplet_kit/mappings/load_balancer_mapping.rb
@@ -27,6 +27,7 @@ module DropletKit
         property :sticky_sessions, include: StickySessionMapping
         property :health_check, include: HealthCheckMapping
         property :forwarding_rules, plural: true, include: ForwardingRuleMapping
+        property :disable_lets_encrypt_dns_records
       end
 
       scoped  :update, :create do

--- a/lib/droplet_kit/models/load_balancer.rb
+++ b/lib/droplet_kit/models/load_balancer.rb
@@ -12,6 +12,7 @@ module DropletKit
     attribute :redirect_http_to_https, Boolean, :default => false
     attribute :enable_proxy_protocol, Boolean, :default => false
     attribute :enable_backend_keepalive, Boolean, :default => false
+    attribute :disable_lets_encrypt_dns_records, Boolean, :default => false
     attribute :droplet_ids
     attribute :sticky_sessions, StickySession
     attribute :health_check

--- a/spec/fixtures/load_balancers/all.json
+++ b/spec/fixtures/load_balancers/all.json
@@ -58,7 +58,8 @@
       ],
       "redirect_http_to_https": false,
       "enable_proxy_protocol": false,
-      "enable_backend_keepalive": false
+      "enable_backend_keepalive": false,
+      "disable_lets_encrypt_dns_records": true
     },
     {
       "id": "3de7ac8b-495b-4884-9a69-1050c6793cd6",
@@ -124,7 +125,8 @@
       "droplet_ids": [],
       "redirect_http_to_https": true,
       "enable_proxy_protocol": false,
-      "enable_backend_keepalive": false
+      "enable_backend_keepalive": false,
+      "disable_lets_encrypt_dns_records": false
     },
     {
       "id": "3de7ac8b-495b-4884-9a69-1050c6793cd6",
@@ -190,7 +192,8 @@
       "droplet_ids": [],
       "redirect_http_to_https": true,
       "enable_proxy_protocol": false,
-      "enable_backend_keepalive": false
+      "enable_backend_keepalive": false,
+      "disable_lets_encrypt_dns_records": false
     }
   ],
   "links": {

--- a/spec/fixtures/load_balancers/find.json
+++ b/spec/fixtures/load_balancers/find.json
@@ -57,6 +57,7 @@
     ],
     "redirect_http_to_https": false,
     "enable_proxy_protocol": false,
-    "enable_backend_keepalive": false
+    "enable_backend_keepalive": false,
+    "disable_lets_encrypt_dns_records": true
   }
 }

--- a/spec/lib/droplet_kit/resources/load_balancer_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/load_balancer_resource_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe DropletKit::LoadBalancerResource do
                                    check_interval_seconds: 10, response_timeout_seconds: 5,
                                    healthy_threshold: 5, unhealthy_threshold: 3))
       expect(load_balancer.forwarding_rules.count).to eq(2)
+      expect(load_balancer.disable_lets_encrypt_dns_records).to eq(true)
       expect(load_balancer.forwarding_rules.first.attributes)
         .to match(a_hash_including(entry_protocol: 'http', entry_port: 80,
                                    target_protocol: 'http', target_port: 80,
@@ -81,6 +82,7 @@ RSpec.describe DropletKit::LoadBalancerResource do
         enable_backend_keepalive: true,
         region: 'nyc1',
         size: 'lb-small',
+        disable_lets_encrypt_dns_records: true,
         forwarding_rules: [
           DropletKit::ForwardingRule.new(
             entry_protocol: 'https',


### PR DESCRIPTION
This adds support for the new `disable_lets_encrypt_dns` field which will disable automatic DNS record creation using the root domain when a let's encrypt cert is added to a load balancer.