### PR TITLE
load-balancers: add support for size_unit field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Version 3.16.0
 
-- #266 load balancers: add new field disable_lets_encrypt_dns_records - @dikshant
+- #286 load balancers: add new field disable_lets_encrypt_dns_records - @dikshant
+- #287 load balancers: add new field size_unit - @dikshant
 
 ## Version 3.15.0
 

--- a/lib/droplet_kit/mappings/load_balancer_mapping.rb
+++ b/lib/droplet_kit/mappings/load_balancer_mapping.rb
@@ -13,6 +13,7 @@ module DropletKit
         property :created_at
         property :region, include: RegionMapping
         property :size
+        property :size_unit
         property :vpc_uuid
       end
 
@@ -33,6 +34,7 @@ module DropletKit
       scoped  :update, :create do
         property :region
         property :size
+        property :size_unit
       end
 
       scoped :create do

--- a/lib/droplet_kit/models/load_balancer.rb
+++ b/lib/droplet_kit/models/load_balancer.rb
@@ -9,6 +9,7 @@ module DropletKit
     attribute :tag
     attribute :region
     attribute :size
+    attribute :size_unit
     attribute :redirect_http_to_https, Boolean, :default => false
     attribute :enable_proxy_protocol, Boolean, :default => false
     attribute :enable_backend_keepalive, Boolean, :default => false

--- a/spec/fixtures/load_balancers/all.json
+++ b/spec/fixtures/load_balancers/all.json
@@ -40,6 +40,7 @@
         "cookie_ttl_seconds": 5
       },
       "size": "lb-small",
+      "size_unit": 1,
       "region": {
         "name": "New York 3",
         "slug": "nyc3",
@@ -93,6 +94,7 @@
         "cookie_ttl_seconds": 5
       },
       "size": "lb-small",
+      "size_unit": 1,
       "region": {
         "name": "New York 3",
         "slug": "nyc3",
@@ -160,6 +162,7 @@
         "cookie_ttl_seconds": 5
       },
       "size": "lb-medium",
+      "size_unit": 1,
       "region": {
         "name": "New York 3",
         "slug": "nyc3",

--- a/spec/fixtures/load_balancers/find.json
+++ b/spec/fixtures/load_balancers/find.json
@@ -39,6 +39,7 @@
       "cookie_ttl_seconds": 5
     },
     "size": "lb-small",
+    "size_unit": 1,
     "region": {
       "name": "New York 3",
       "slug": "nyc3",

--- a/spec/lib/droplet_kit/resources/load_balancer_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/load_balancer_resource_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe DropletKit::LoadBalancerResource do
       expect(load_balancer.created_at).to eq('2017-02-01T22:22:58Z')
       expect(load_balancer.tag).to be_blank
       expect(load_balancer.size).to eq('lb-small')
+      expect(load_balancer.size_unit).to eq(1)
       expect(load_balancer.region).to be_kind_of(DropletKit::Region)
       expect(load_balancer.region.attributes)
         .to match(a_hash_including(slug: 'nyc3', name: 'New York 3',
@@ -82,6 +83,7 @@ RSpec.describe DropletKit::LoadBalancerResource do
         enable_backend_keepalive: true,
         region: 'nyc1',
         size: 'lb-small',
+        size_unit: 1,
         disable_lets_encrypt_dns_records: true,
         forwarding_rules: [
           DropletKit::ForwardingRule.new(


### PR DESCRIPTION
This adds the new size_unit field. Users can now supply the size_unit as an integer > 1 instead of using `lb_size`