### PR TITLE
Add frozen_string_literal: true comment to all files

### DIFF
--- a/lib/droplet_kit.rb
+++ b/lib/droplet_kit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'droplet_kit/version'
 require 'resource_kit'
 require 'kartograph'

--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require 'droplet_kit/utils'
 

--- a/lib/droplet_kit/error_handling_resourcable.rb
+++ b/lib/droplet_kit/error_handling_resourcable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ErrorHandlingResourcable
   def self.included(base)
     base.send(:resources) do

--- a/lib/droplet_kit/mappings/account_mapping.rb
+++ b/lib/droplet_kit/mappings/account_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class AccountMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/action_mapping.rb
+++ b/lib/droplet_kit/mappings/action_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ActionMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/balance_mapping.rb
+++ b/lib/droplet_kit/mappings/balance_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class BalanceMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/cdn_mapping.rb
+++ b/lib/droplet_kit/mappings/cdn_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class CDNMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/certificate_mapping.rb
+++ b/lib/droplet_kit/mappings/certificate_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class CertificateMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/container_registry_mapping.rb
+++ b/lib/droplet_kit/mappings/container_registry_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ContainerRegistryMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/container_registry_repository_mapping.rb
+++ b/lib/droplet_kit/mappings/container_registry_repository_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ContainerRegistryRepositoryMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/container_registry_repository_tag_mapping.rb
+++ b/lib/droplet_kit/mappings/container_registry_repository_tag_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ContainerRegistryRepositoryTagMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_backup_mapping.rb
+++ b/lib/droplet_kit/mappings/database_backup_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseBackupMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_backup_restore_mapping.rb
+++ b/lib/droplet_kit/mappings/database_backup_restore_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseBackupRestoreMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_cluster_mapping.rb
+++ b/lib/droplet_kit/mappings/database_cluster_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseClusterMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_connection_mapping.rb
+++ b/lib/droplet_kit/mappings/database_connection_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseConnectionMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_connection_pool_mapping.rb
+++ b/lib/droplet_kit/mappings/database_connection_pool_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseConnectionPoolMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_eviction_policy_mapping.rb
+++ b/lib/droplet_kit/mappings/database_eviction_policy_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseEvictionPolicyMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_firewall_rule_mapping.rb
+++ b/lib/droplet_kit/mappings/database_firewall_rule_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseFirewallRuleMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_maintenance_window_mapping.rb
+++ b/lib/droplet_kit/mappings/database_maintenance_window_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseMaintenanceWindowMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_mapping.rb
+++ b/lib/droplet_kit/mappings/database_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_replica_mapping.rb
+++ b/lib/droplet_kit/mappings/database_replica_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseReplicaMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_sql_mode_mapping.rb
+++ b/lib/droplet_kit/mappings/database_sql_mode_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseSQLModeMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_user_mapping.rb
+++ b/lib/droplet_kit/mappings/database_user_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseUserMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/database_user_reset_auth_mapping.rb
+++ b/lib/droplet_kit/mappings/database_user_reset_auth_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseUserResetAuthMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/domain_mapping.rb
+++ b/lib/droplet_kit/mappings/domain_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DomainMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/domain_record_mapping.rb
+++ b/lib/droplet_kit/mappings/domain_record_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DomainRecordMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/droplet_mapping.rb
+++ b/lib/droplet_kit/mappings/droplet_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DropletMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/droplet_upgrade_mapping.rb
+++ b/lib/droplet_kit/mappings/droplet_upgrade_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DropletUpgradeMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/error_mapping.rb
+++ b/lib/droplet_kit/mappings/error_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ErrorMapping
     Error = Struct.new(:message, :id)

--- a/lib/droplet_kit/mappings/firewall_inbound_rule_mapping.rb
+++ b/lib/droplet_kit/mappings/firewall_inbound_rule_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FirewallInboundRuleMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/firewall_mapping.rb
+++ b/lib/droplet_kit/mappings/firewall_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FirewallMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/firewall_outbound_rule_mapping.rb
+++ b/lib/droplet_kit/mappings/firewall_outbound_rule_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FirewallOutboundRuleMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/firewall_pending_change_mapping.rb
+++ b/lib/droplet_kit/mappings/firewall_pending_change_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FirewallPendingChangeMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/firewall_rule_mapping.rb
+++ b/lib/droplet_kit/mappings/firewall_rule_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FirewallRuleMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/floating_ip_mapping.rb
+++ b/lib/droplet_kit/mappings/floating_ip_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FloatingIpMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/forwarding_rule_mapping.rb
+++ b/lib/droplet_kit/mappings/forwarding_rule_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ForwardingRuleMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/health_check_mapping.rb
+++ b/lib/droplet_kit/mappings/health_check_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class HealthCheckMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/image_mapping.rb
+++ b/lib/droplet_kit/mappings/image_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ImageMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/invoice_mapping.rb
+++ b/lib/droplet_kit/mappings/invoice_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class InvoiceMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/kernel_mapping.rb
+++ b/lib/droplet_kit/mappings/kernel_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KernelMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/kubernetes_cluster_mapping.rb
+++ b/lib/droplet_kit/mappings/kubernetes_cluster_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesClusterMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/kubernetes_maintenance_policy_mapping.rb
+++ b/lib/droplet_kit/mappings/kubernetes_maintenance_policy_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesMaintenancePolicyMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/kubernetes_node_mapping.rb
+++ b/lib/droplet_kit/mappings/kubernetes_node_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesNodeMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/kubernetes_node_pool_mapping.rb
+++ b/lib/droplet_kit/mappings/kubernetes_node_pool_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesNodePoolMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/kubernetes_options_mapping.rb
+++ b/lib/droplet_kit/mappings/kubernetes_options_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesOptionsMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/links_mapping.rb
+++ b/lib/droplet_kit/mappings/links_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class LinksMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/load_balancer_mapping.rb
+++ b/lib/droplet_kit/mappings/load_balancer_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class LoadBalancerMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/network_detail_mapping.rb
+++ b/lib/droplet_kit/mappings/network_detail_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class NetworkDetailMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/network_mapping.rb
+++ b/lib/droplet_kit/mappings/network_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class NetworkMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/project_assignment_mapping.rb
+++ b/lib/droplet_kit/mappings/project_assignment_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ProjectAssignmentMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/project_mapping.rb
+++ b/lib/droplet_kit/mappings/project_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ProjectMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/region_mapping.rb
+++ b/lib/droplet_kit/mappings/region_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class RegionMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/size_mapping.rb
+++ b/lib/droplet_kit/mappings/size_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class SizeMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/snapshot_mapping.rb
+++ b/lib/droplet_kit/mappings/snapshot_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class SnapshotMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/ssh_key_mapping.rb
+++ b/lib/droplet_kit/mappings/ssh_key_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class SSHKeyMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/sticky_session_mapping.rb
+++ b/lib/droplet_kit/mappings/sticky_session_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class StickySessionMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/tag_mapping.rb
+++ b/lib/droplet_kit/mappings/tag_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class TagMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/tagged_droplets_resources_mapping.rb
+++ b/lib/droplet_kit/mappings/tagged_droplets_resources_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class TaggedDropletsResourcesMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/tagged_images_resources_mapping.rb
+++ b/lib/droplet_kit/mappings/tagged_images_resources_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class TaggedImagesResourcesMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/tagged_resources_mapping.rb
+++ b/lib/droplet_kit/mappings/tagged_resources_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class TaggedResourcesMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/volume_mapping.rb
+++ b/lib/droplet_kit/mappings/volume_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class VolumeMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/vpc_mapping.rb
+++ b/lib/droplet_kit/mappings/vpc_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class VPCMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/mappings/vpc_member_mapping.rb
+++ b/lib/droplet_kit/mappings/vpc_member_mapping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class VPCMemberMapping
     include Kartograph::DSL

--- a/lib/droplet_kit/models/account.rb
+++ b/lib/droplet_kit/models/account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Account < BaseModel
     attribute :droplet_limit

--- a/lib/droplet_kit/models/action.rb
+++ b/lib/droplet_kit/models/action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Action < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/balance.rb
+++ b/lib/droplet_kit/models/balance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Balance < BaseModel
     attribute :month_to_date_balance

--- a/lib/droplet_kit/models/base_model.rb
+++ b/lib/droplet_kit/models/base_model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'virtus'
 require 'droplet_kit/utils'
 

--- a/lib/droplet_kit/models/cdn.rb
+++ b/lib/droplet_kit/models/cdn.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class CDN < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/certificate.rb
+++ b/lib/droplet_kit/models/certificate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Certificate < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/container_registry.rb
+++ b/lib/droplet_kit/models/container_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ContainerRegistry < BaseModel
     [:name].each do |key|

--- a/lib/droplet_kit/models/container_registry_repository.rb
+++ b/lib/droplet_kit/models/container_registry_repository.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ContainerRegistryRepository < BaseModel
     [:registry_name,:name,:latest_tag,:tag_count].each do |key|

--- a/lib/droplet_kit/models/container_registry_repository_tag.rb
+++ b/lib/droplet_kit/models/container_registry_repository_tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ContainerRegistryRepositoryTag < BaseModel
     [:registry_name,:repository,:tag,:manifest_digest,:compressed_size_bytes,:size_bytes,:updated_at].each do |key|

--- a/lib/droplet_kit/models/database.rb
+++ b/lib/droplet_kit/models/database.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Database < BaseModel
     attribute :name

--- a/lib/droplet_kit/models/database_backup.rb
+++ b/lib/droplet_kit/models/database_backup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseBackup < BaseModel
     attribute :created_at

--- a/lib/droplet_kit/models/database_cluster.rb
+++ b/lib/droplet_kit/models/database_cluster.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseCluster < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/database_connection.rb
+++ b/lib/droplet_kit/models/database_connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseConnection < BaseModel
     attribute :uri

--- a/lib/droplet_kit/models/database_connection_pool.rb
+++ b/lib/droplet_kit/models/database_connection_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseConnectionPool < BaseModel
     attribute :name

--- a/lib/droplet_kit/models/database_eviction_policy.rb
+++ b/lib/droplet_kit/models/database_eviction_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseEvictionPolicy < BaseModel
     attribute :eviction_policy

--- a/lib/droplet_kit/models/database_firewall_rule.rb
+++ b/lib/droplet_kit/models/database_firewall_rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseFirewallRule < BaseModel
     attribute :type

--- a/lib/droplet_kit/models/database_maintenance_window.rb
+++ b/lib/droplet_kit/models/database_maintenance_window.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseMaintenanceWindow < BaseModel
     attribute :day

--- a/lib/droplet_kit/models/database_replica.rb
+++ b/lib/droplet_kit/models/database_replica.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseReplica < BaseModel
     attribute :replicas

--- a/lib/droplet_kit/models/database_sql_mode.rb
+++ b/lib/droplet_kit/models/database_sql_mode.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseSQLMode < BaseModel
     attribute :sql_mode

--- a/lib/droplet_kit/models/database_user.rb
+++ b/lib/droplet_kit/models/database_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseUser < BaseModel
     attribute :name

--- a/lib/droplet_kit/models/database_user_mysql_settings.rb
+++ b/lib/droplet_kit/models/database_user_mysql_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseUserMySQLSettings < BaseModel
     attribute :auth_plugin

--- a/lib/droplet_kit/models/database_user_reset_auth.rb
+++ b/lib/droplet_kit/models/database_user_reset_auth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseUserResetAuth < BaseModel
     attribute :mysql_settings

--- a/lib/droplet_kit/models/domain.rb
+++ b/lib/droplet_kit/models/domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Domain < BaseModel
     attribute :name

--- a/lib/droplet_kit/models/domain_record.rb
+++ b/lib/droplet_kit/models/domain_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DomainRecord < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/droplet.rb
+++ b/lib/droplet_kit/models/droplet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Droplet < BaseModel
     [:id, :name, :memory, :vcpus, :disk, :locked, :created_at,

--- a/lib/droplet_kit/models/droplet_upgrade.rb
+++ b/lib/droplet_kit/models/droplet_upgrade.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DropletUpgrade < BaseModel
     attribute :droplet_id

--- a/lib/droplet_kit/models/firewall.rb
+++ b/lib/droplet_kit/models/firewall.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Firewall < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/firewall_inbound_rule.rb
+++ b/lib/droplet_kit/models/firewall_inbound_rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FirewallInboundRule < BaseModel
     attribute :protocol

--- a/lib/droplet_kit/models/firewall_outbound_rule.rb
+++ b/lib/droplet_kit/models/firewall_outbound_rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FirewallOutboundRule < BaseModel
     attribute :protocol

--- a/lib/droplet_kit/models/firewall_pending_change.rb
+++ b/lib/droplet_kit/models/firewall_pending_change.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FirewallPendingChange < BaseModel
     attribute :droplet_id

--- a/lib/droplet_kit/models/firewall_rule.rb
+++ b/lib/droplet_kit/models/firewall_rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FirewallRule < BaseModel
     attribute :inbound_rules

--- a/lib/droplet_kit/models/floating_ip.rb
+++ b/lib/droplet_kit/models/floating_ip.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FloatingIp < BaseModel
     attribute :ip

--- a/lib/droplet_kit/models/forwarding_rule.rb
+++ b/lib/droplet_kit/models/forwarding_rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ForwardingRule < BaseModel
     attribute :entry_protocol

--- a/lib/droplet_kit/models/health_check.rb
+++ b/lib/droplet_kit/models/health_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class HealthCheck < BaseModel
     attribute :protocol

--- a/lib/droplet_kit/models/image.rb
+++ b/lib/droplet_kit/models/image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Image < BaseModel
     # @!attribute id

--- a/lib/droplet_kit/models/invoice.rb
+++ b/lib/droplet_kit/models/invoice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
     class Invoice < BaseModel
       attribute :invoice_uuid

--- a/lib/droplet_kit/models/kernel.rb
+++ b/lib/droplet_kit/models/kernel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Kernel < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/kubernetes_cluster.rb
+++ b/lib/droplet_kit/models/kubernetes_cluster.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesCluster < BaseModel
     [:id, :name, :region, :version, :auto_upgrade, :cluster_subnet, :service_subnet, :ipv4, :endpoint, :tags, :maintenance_policy, :node_pools, :vpc_uuid, :ha].each do |key|

--- a/lib/droplet_kit/models/kubernetes_maintenance_policy.rb
+++ b/lib/droplet_kit/models/kubernetes_maintenance_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesMaintenancePolicy < BaseModel
     attribute :start_time

--- a/lib/droplet_kit/models/kubernetes_node.rb
+++ b/lib/droplet_kit/models/kubernetes_node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesNode < BaseModel
     [:id, :name, :status, :created_at, :updated_at].each do |key|

--- a/lib/droplet_kit/models/kubernetes_node_pool.rb
+++ b/lib/droplet_kit/models/kubernetes_node_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesNodePool < BaseModel
     [:id, :name, :size, :count, :tags, :labels, :nodes, :auto_scale, :min_nodes, :max_nodes].each do |key|

--- a/lib/droplet_kit/models/kubernetes_options.rb
+++ b/lib/droplet_kit/models/kubernetes_options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesOptions < BaseModel
     attribute :versions

--- a/lib/droplet_kit/models/links.rb
+++ b/lib/droplet_kit/models/links.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Links < BaseModel
     attribute :myself

--- a/lib/droplet_kit/models/load_balancer.rb
+++ b/lib/droplet_kit/models/load_balancer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class LoadBalancer < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/meta_information.rb
+++ b/lib/droplet_kit/models/meta_information.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class MetaInformation < BaseModel
     include Kartograph::DSL

--- a/lib/droplet_kit/models/network.rb
+++ b/lib/droplet_kit/models/network.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   Network = Struct.new(:ip_address, :netmask, :gateway, :type, :cidr)
 end

--- a/lib/droplet_kit/models/network_hash.rb
+++ b/lib/droplet_kit/models/network_hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   NetworkHash = Struct.new(:v4, :v6)
 end

--- a/lib/droplet_kit/models/pagination_information.rb
+++ b/lib/droplet_kit/models/pagination_information.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class PaginationInformation < BaseModel
     include Kartograph::DSL

--- a/lib/droplet_kit/models/project.rb
+++ b/lib/droplet_kit/models/project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Project < BaseModel
     DEFAULT = 'default'.freeze

--- a/lib/droplet_kit/models/project_assignment.rb
+++ b/lib/droplet_kit/models/project_assignment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ProjectAssignment < BaseModel
     attribute :urn

--- a/lib/droplet_kit/models/region.rb
+++ b/lib/droplet_kit/models/region.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Region < BaseModel
     attribute :slug

--- a/lib/droplet_kit/models/size.rb
+++ b/lib/droplet_kit/models/size.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Size < BaseModel
     attribute :slug

--- a/lib/droplet_kit/models/snapshot.rb
+++ b/lib/droplet_kit/models/snapshot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Snapshot < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/ssh_key.rb
+++ b/lib/droplet_kit/models/ssh_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class SSHKey < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/sticky_session.rb
+++ b/lib/droplet_kit/models/sticky_session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class StickySession < BaseModel
     attribute :type, String

--- a/lib/droplet_kit/models/tag.rb
+++ b/lib/droplet_kit/models/tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Tag < BaseModel
     attribute :name

--- a/lib/droplet_kit/models/tagged_droplets_resources.rb
+++ b/lib/droplet_kit/models/tagged_droplets_resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class TaggedDropletsResources < BaseModel
     attribute :count

--- a/lib/droplet_kit/models/tagged_images_resources.rb
+++ b/lib/droplet_kit/models/tagged_images_resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class TaggedImagesResources < BaseModel
     attribute :count

--- a/lib/droplet_kit/models/tagged_resources.rb
+++ b/lib/droplet_kit/models/tagged_resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class TaggedResources < BaseModel
     attribute :count

--- a/lib/droplet_kit/models/volume.rb
+++ b/lib/droplet_kit/models/volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class Volume < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/vpc.rb
+++ b/lib/droplet_kit/models/vpc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class VPC < BaseModel
     attribute :id

--- a/lib/droplet_kit/models/vpc_member.rb
+++ b/lib/droplet_kit/models/vpc_member.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class VPCMember < BaseModel
     attribute :urn

--- a/lib/droplet_kit/paginated_resource.rb
+++ b/lib/droplet_kit/paginated_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class PaginatedResource
     include Enumerable

--- a/lib/droplet_kit/resources/account_resource.rb
+++ b/lib/droplet_kit/resources/account_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class AccountResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/action_resource.rb
+++ b/lib/droplet_kit/resources/action_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ActionResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/balance_resource.rb
+++ b/lib/droplet_kit/resources/balance_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class BalanceResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/cdn_resource.rb
+++ b/lib/droplet_kit/resources/cdn_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class CDNResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/certificate_resource.rb
+++ b/lib/droplet_kit/resources/certificate_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class CertificateResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/container_registry_repository_resource.rb
+++ b/lib/droplet_kit/resources/container_registry_repository_resource.rb
@@ -1,35 +1,36 @@
+# frozen_string_literal: true
+
 module DropletKit
-    class ContainerRegistryRepositoryResource < ResourceKit::Resource
-      include ErrorHandlingResourcable
-  
-      resources do
-        action :all, 'GET /v2/registry/:registry_name/repositories' do
-          query_keys :per_page, :page
-          handler(200) { |response| ContainerRegistryRepositoryMapping.extract_collection(response.body, :read) }
-        end
+  class ContainerRegistryRepositoryResource < ResourceKit::Resource
+    include ErrorHandlingResourcable
 
-        action :tags, 'GET /v2/registry/:registry_name/repositories/:repository/tags' do
-          query_keys :per_page, :page
-          handler(200) { |response| DropletKit::ContainerRegistryRepositoryTagMapping.extract_collection(response.body, :read) }
-        end
-
-        action :delete_tag, 'DELETE /v2/registry/:registry_name/repositories/:repository/tags/:tag' do
-          handler(204) { |response| true }
-        end
-
-        action :delete_manifest, 'DELETE /v2/registry/:registry_name/repositories/:repository/digests/:manifest_digest' do
-          handler(204) { |response| true }
-          handler(400) { |response| ErrorMapping.fail_with(FailedDelete, response.body) }
-        end
+    resources do
+      action :all, 'GET /v2/registry/:registry_name/repositories' do
+        query_keys :per_page, :page
+        handler(200) { |response| ContainerRegistryRepositoryMapping.extract_collection(response.body, :read) }
       end
 
-      def all(*args)
-        PaginatedResource.new(action(:all), self, *args)
+      action :tags, 'GET /v2/registry/:registry_name/repositories/:repository/tags' do
+        query_keys :per_page, :page
+        handler(200) { |response| DropletKit::ContainerRegistryRepositoryTagMapping.extract_collection(response.body, :read) }
       end
 
-      def tags(*args)
-        PaginatedResource.new(action(:tags), self, *args)
+      action :delete_tag, 'DELETE /v2/registry/:registry_name/repositories/:repository/tags/:tag' do
+        handler(204) { |response| true }
+      end
+
+      action :delete_manifest, 'DELETE /v2/registry/:registry_name/repositories/:repository/digests/:manifest_digest' do
+        handler(204) { |response| true }
+        handler(400) { |response| ErrorMapping.fail_with(FailedDelete, response.body) }
       end
     end
+
+    def all(*args)
+      PaginatedResource.new(action(:all), self, *args)
+    end
+
+    def tags(*args)
+      PaginatedResource.new(action(:tags), self, *args)
+    end
+  end
 end
-  

--- a/lib/droplet_kit/resources/container_registry_resource.rb
+++ b/lib/droplet_kit/resources/container_registry_resource.rb
@@ -1,26 +1,27 @@
-module DropletKit
-    class ContainerRegistryResource < ResourceKit::Resource
-      include ErrorHandlingResourcable
-  
-      resources do
-        action :get, 'GET /v2/registry' do
-          handler(200) { |response| ContainerRegistryMapping.extract_single(response.body, :read) }
-        end
-  
-        action :create, 'POST /v2/registry' do
-          body { |object| ContainerRegistryMapping.representation_for(:create, object) }
-          handler(201) { |response, registry| ContainerRegistryMapping.extract_into_object(registry, response.body, :read) }
-          handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
-        end
-  
-        action :delete, 'DELETE /v2/registry' do
-          handler(204) { |response| true }
-        end
+# frozen_string_literal: true
 
-        action :docker_credentials, 'GET /v2/registry/docker-credentials' do
-          handler(200) { |response| response.body }
-        end
+module DropletKit
+  class ContainerRegistryResource < ResourceKit::Resource
+    include ErrorHandlingResourcable
+
+    resources do
+      action :get, 'GET /v2/registry' do
+        handler(200) { |response| ContainerRegistryMapping.extract_single(response.body, :read) }
+      end
+
+      action :create, 'POST /v2/registry' do
+        body { |object| ContainerRegistryMapping.representation_for(:create, object) }
+        handler(201) { |response, registry| ContainerRegistryMapping.extract_into_object(registry, response.body, :read) }
+        handler(422) { |response| ErrorMapping.fail_with(FailedCreate, response.body) }
+      end
+
+      action :delete, 'DELETE /v2/registry' do
+        handler(204) { |response| true }
+      end
+
+      action :docker_credentials, 'GET /v2/registry/docker-credentials' do
+        handler(200) { |response| response.body }
       end
     end
+  end
 end
-  

--- a/lib/droplet_kit/resources/database_resource.rb
+++ b/lib/droplet_kit/resources/database_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DatabaseResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/domain_record_resource.rb
+++ b/lib/droplet_kit/resources/domain_record_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DomainRecordResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/domain_resource.rb
+++ b/lib/droplet_kit/resources/domain_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DomainResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/droplet_action_resource.rb
+++ b/lib/droplet_kit/resources/droplet_action_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DropletActionResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/droplet_resource.rb
+++ b/lib/droplet_kit/resources/droplet_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DropletResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/droplet_upgrade_resource.rb
+++ b/lib/droplet_kit/resources/droplet_upgrade_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class DropletUpgradeResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/firewall_resource.rb
+++ b/lib/droplet_kit/resources/firewall_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FirewallResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/floating_ip_action_resource.rb
+++ b/lib/droplet_kit/resources/floating_ip_action_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FloatingIpActionResource < ResourceKit::Resource
     resources do

--- a/lib/droplet_kit/resources/floating_ip_resource.rb
+++ b/lib/droplet_kit/resources/floating_ip_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class FloatingIpResource < ResourceKit::Resource
     resources do

--- a/lib/droplet_kit/resources/image_action_resource.rb
+++ b/lib/droplet_kit/resources/image_action_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ImageActionResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/image_resource.rb
+++ b/lib/droplet_kit/resources/image_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ImageResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/invoice_resource.rb
+++ b/lib/droplet_kit/resources/invoice_resource.rb
@@ -1,15 +1,17 @@
-module DropletKit
-    class InvoiceResource < ResourceKit::Resource
-      include ErrorHandlingResourcable
-  
-      resources do
-        action :list, 'GET /v2/customers/my/invoices' do
-          handler(200) { |response| InvoiceMapping.extract_collection(response.body, :read) }
-        end
+# frozen_string_literal: true
 
-        action :find, 'GET v2/customers/my/invoices/:id' do
-          handler(200) { |response| InvoiceMapping.extract_collection(response.body, :find) }
-        end
+module DropletKit
+  class InvoiceResource < ResourceKit::Resource
+    include ErrorHandlingResourcable
+
+    resources do
+      action :list, 'GET /v2/customers/my/invoices' do
+        handler(200) { |response| InvoiceMapping.extract_collection(response.body, :read) }
+      end
+
+      action :find, 'GET v2/customers/my/invoices/:id' do
+        handler(200) { |response| InvoiceMapping.extract_collection(response.body, :find) }
       end
     end
   end
+end

--- a/lib/droplet_kit/resources/kubernetes_cluster_resource.rb
+++ b/lib/droplet_kit/resources/kubernetes_cluster_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesClusterResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/kubernetes_options_resource.rb
+++ b/lib/droplet_kit/resources/kubernetes_options_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class KubernetesOptionsResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/load_balancer_resource.rb
+++ b/lib/droplet_kit/resources/load_balancer_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class LoadBalancerResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/project_resource.rb
+++ b/lib/droplet_kit/resources/project_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class ProjectResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/region_resource.rb
+++ b/lib/droplet_kit/resources/region_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class RegionResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/size_resource.rb
+++ b/lib/droplet_kit/resources/size_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class SizeResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/snapshot_resource.rb
+++ b/lib/droplet_kit/resources/snapshot_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class SnapshotResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/ssh_key_resource.rb
+++ b/lib/droplet_kit/resources/ssh_key_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class SSHKeyResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/tag_resource.rb
+++ b/lib/droplet_kit/resources/tag_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class TagResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/volume_action_resource.rb
+++ b/lib/droplet_kit/resources/volume_action_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class VolumeActionResource < ResourceKit::Resource
     resources do

--- a/lib/droplet_kit/resources/volume_resource.rb
+++ b/lib/droplet_kit/resources/volume_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class VolumeResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/resources/vpc_resource.rb
+++ b/lib/droplet_kit/resources/vpc_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   class VPCResource < ResourceKit::Resource
     include ErrorHandlingResourcable

--- a/lib/droplet_kit/utils.rb
+++ b/lib/droplet_kit/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   module Utils
     def self.camelize(term)

--- a/lib/droplet_kit/version.rb
+++ b/lib/droplet_kit/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKit
   VERSION = "3.16.0"
 end

--- a/lib/tasks/resource_doc.rake
+++ b/lib/tasks/resource_doc.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'droplet_kit'
 require 'droplet_kit/utils'
 

--- a/spec/lib/droplet_kit/client_spec.rb
+++ b/spec/lib/droplet_kit/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::Client do

--- a/spec/lib/droplet_kit/models/base_model_spec.rb
+++ b/spec/lib/droplet_kit/models/base_model_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::BaseModel do

--- a/spec/lib/droplet_kit/models/droplet_spec.rb
+++ b/spec/lib/droplet_kit/models/droplet_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::Droplet do

--- a/spec/lib/droplet_kit/models/loadbalancer_spec.rb
+++ b/spec/lib/droplet_kit/models/loadbalancer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::LoadBalancer do

--- a/spec/lib/droplet_kit/paginated_resource_spec.rb
+++ b/spec/lib/droplet_kit/paginated_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RequestCounter = Struct.new(:count)

--- a/spec/lib/droplet_kit/resources/account_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/account_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::AccountResource do

--- a/spec/lib/droplet_kit/resources/action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/action_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::ActionResource do

--- a/spec/lib/droplet_kit/resources/balance_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/balance_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::BalanceResource do

--- a/spec/lib/droplet_kit/resources/cdn_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/cdn_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::CDNResource do

--- a/spec/lib/droplet_kit/resources/certificate_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/certificate_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::CertificateResource do

--- a/spec/lib/droplet_kit/resources/container_registry_repository_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/container_registry_repository_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::ContainerRegistryRepositoryResource do

--- a/spec/lib/droplet_kit/resources/container_registry_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/container_registry_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::ContainerRegistryResource do

--- a/spec/lib/droplet_kit/resources/database_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/database_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::DatabaseResource do

--- a/spec/lib/droplet_kit/resources/domain_record_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/domain_record_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::DomainRecordResource do

--- a/spec/lib/droplet_kit/resources/domain_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/domain_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::DomainResource do

--- a/spec/lib/droplet_kit/resources/droplet_action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_action_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::DropletActionResource do

--- a/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::DropletResource do

--- a/spec/lib/droplet_kit/resources/droplet_upgrade_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_upgrade_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::DropletUpgradeResource do

--- a/spec/lib/droplet_kit/resources/firewall_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/firewall_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::FirewallResource do

--- a/spec/lib/droplet_kit/resources/floating_ip_action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/floating_ip_action_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::FloatingIpActionResource do

--- a/spec/lib/droplet_kit/resources/floating_ip_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/floating_ip_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::FloatingIpResource do

--- a/spec/lib/droplet_kit/resources/image_action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/image_action_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::ImageActionResource do

--- a/spec/lib/droplet_kit/resources/image_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/image_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::ImageResource do

--- a/spec/lib/droplet_kit/resources/invoice_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/invoice_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::InvoiceResource do

--- a/spec/lib/droplet_kit/resources/kubernetes_cluster_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/kubernetes_cluster_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::KubernetesClusterResource do

--- a/spec/lib/droplet_kit/resources/kubernetes_options_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/kubernetes_options_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::KubernetesOptionsResource do

--- a/spec/lib/droplet_kit/resources/load_balancer_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/load_balancer_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::LoadBalancerResource do

--- a/spec/lib/droplet_kit/resources/project_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/project_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe DropletKit::ProjectResource do

--- a/spec/lib/droplet_kit/resources/region_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/region_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::RegionResource do

--- a/spec/lib/droplet_kit/resources/size_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/size_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::SizeResource do

--- a/spec/lib/droplet_kit/resources/snapshot_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/snapshot_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::SnapshotResource do

--- a/spec/lib/droplet_kit/resources/ssh_key_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/ssh_key_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::SSHKeyResource do

--- a/spec/lib/droplet_kit/resources/tag_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/tag_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe DropletKit::TagResource do

--- a/spec/lib/droplet_kit/resources/volume_action_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/volume_action_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::VolumeActionResource do

--- a/spec/lib/droplet_kit/resources/volume_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/volume_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::VolumeResource do

--- a/spec/lib/droplet_kit/resources/vpc_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/vpc_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DropletKit::VPCResource do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 
 SimpleCov.start

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DropletKitHelpers
   BLANK_RE = /\A[[:space:]]*\z/
 

--- a/spec/support/request_stub_helpers.rb
+++ b/spec/support/request_stub_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RequestStubHelpers
   def stub_do_api(path, verb = :any)
     stub_request(verb, %r[#{DropletKit::Client::DIGITALOCEAN_API}#{Regexp.escape(path)}])

--- a/spec/support/resource_context.rb
+++ b/spec/support/resource_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_context 'resources' do
   let(:client) { DropletKit::Client.new(access_token: 'bunk-token') }
   let(:connection) { client.connection }

--- a/spec/support/shared_examples/common_errors.rb
+++ b/spec/support/shared_examples/common_errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples_for 'resource that handles common errors' do
   let(:arguments) { {} }
 

--- a/spec/support/shared_examples/paginated_endpoint.rb
+++ b/spec/support/shared_examples/paginated_endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # To use this, `fixture_path`, `api_path` and a `resource` must be defined
 # using `let`s.
 shared_examples_for 'a paginated index' do

--- a/spec/support/shared_examples/unprocessable_entity.rb
+++ b/spec/support/shared_examples/unprocessable_entity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples_for 'an action that handles invalid parameters' do
   let(:verb) { :post }
   let(:exception) { DropletKit::FailedCreate }


### PR DESCRIPTION
Attempts to address #289 

While I thought the plan for Ruby 3 was to make `frozen_string_literal: true` the default, I guess that wasn't the case (see [Matz's comment about it](https://bugs.ruby-lang.org/issues/11473#note-53)). This change adds all of the magic `frozen_string_literal: true` comments to the top of the file.

When run in IRB on `main`, this is what I see when trying to use a Ractor to print DropletKit's version:

```irb
 $ irb -I lib -r droplet_kit
irb(main):001:0> r = Ractor.new { puts DropletKit::VERSION }
<internal:ractor>:267: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
#<Thread:0x00007fa85987e160 run> terminated with exception (report_on_exception is true):
(irb):1:in `block in <main>': can not access non-shareable objects in constant DropletKit::VERSION by non-main Ractor. (Ractor::IsolationError)
=> #<Ractor:#2 (irb):1 terminated>
```

which seems to be the error in the linked issue.

This is what I see on this branch:

```irb
$ irb -I lib -r droplet_kit
irb(main):001:0> r = Ractor.new { puts DropletKit::VERSION }
<internal:ractor>:267: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
3.16.0
=> #<Ractor:#2 (irb):1 terminated>
```

Suggesting that it resolves the issue.

I also fixed the whitespace + formatting of a few files. It probably wasn't necessary to add the comment to all of the tests, but I did this with the [`magic_frozen_string_literal`](https://github.com/Invoca/magic_frozen_string_literal) gem which did that by default, so I figured I'd leave it.