### PR TITLE
Upgrade Kartograph and Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ruby: [ 2.5, 2.6, 2.7, 3.0 ]
+        ruby: [ 2.5, 2.6, 2.7, 3.0, 3.1 ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'virtus', '~> 1.0.3'
   spec.add_dependency "resource_kit", '~> 0.1.5'
-  spec.add_dependency "kartograph", '~> 0.2.3'
+  spec.add_dependency "kartograph", '~> 0.2.8'
   spec.add_dependency "faraday", '>= 0.15'
 
   spec.add_development_dependency "bundler", ">= 2.1.2"


### PR DESCRIPTION
Upgrades the Kartograph dependency (which hadn't been touched in about 6 years), and adds Ruby 3.1 to the test matrix.