### PR TITLE
Update `virtus` requirement to allow v2

### DIFF
--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_dependency 'virtus', '~> 1.0.3'
+  spec.add_dependency 'virtus', '>= 1.0.3', '<= 3'
   spec.add_dependency "resource_kit", '~> 0.1.5'
   spec.add_dependency "kartograph", '~> 0.2.8'
   spec.add_dependency "faraday", '>= 0.15'


### PR DESCRIPTION
Not sure why it's locked on v1, but I think it's no harm to allow
installation of the latest version if all test are green