### PR TITLE
Add read size mapping attribute to droplet resource

### DIFF
--- a/lib/droplet_kit/mappings/droplet_mapping.rb
+++ b/lib/droplet_kit/mappings/droplet_mapping.rb
@@ -24,6 +24,7 @@ module DropletKit
       property :tags, scopes: [:read]
       property :vpc_uuid, scopes: [:read]
       property :volume_ids, scopes: [:read]
+      property :size, scopes: [:read], include: SizeMapping
 
       property :region, scopes: [:read], include: RegionMapping
       property :image, scopes: [:read], include: ImageMapping

--- a/spec/fixtures/droplets/all.json
+++ b/spec/fixtures/droplets/all.json
@@ -77,6 +77,21 @@
       "volume_ids": [
         "ffaa8716-59e1-11e8-92b6-0242ac110b0c"
       ],
+      "size": {
+        "slug": "s-1vcpu-1gb",
+        "memory": 1024,
+        "vcpus": 1,
+        "disk": 25,
+        "transfer": 1,
+        "price_monthly": 5,
+        "price_hourly": 0.00743999984115362,
+        "regions": [
+          "nyc1",
+          "nyc2"
+        ],
+        "available": true,
+        "description": "Basic"
+      },
       "action_ids": [
 
       ],

--- a/spec/fixtures/droplets/find.json
+++ b/spec/fixtures/droplets/find.json
@@ -76,6 +76,21 @@
     "volume_ids": [
       "ffaa8716-59e1-11e8-92b6-0242ac110b0c"
     ],
+    "size": {
+      "slug": "s-1vcpu-1gb",
+      "memory": 1024,
+      "vcpus": 1,
+      "disk": 25,
+      "transfer": 1,
+      "price_monthly": 5,
+      "price_hourly": 0.00743999984115362,
+      "regions": [
+        "nyc1",
+        "nyc2"
+      ],
+      "available": true,
+      "description": "Basic"
+    },
     "action_ids": [
 
     ],

--- a/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
@@ -81,6 +81,17 @@ RSpec.describe DropletKit::DropletResource do
       droplets = resource.all
       expect(droplets).to all(be_a(DropletKit::Droplet))
 
+      expect(droplets.first.size).to be_a(DropletKit::Size)
+      expect(droplets.first.size.memory).to eq(1024)
+      expect(droplets.first.size.vcpus).to eq(1)
+      expect(droplets.first.size.disk).to eq(25)
+      expect(droplets.first.size.transfer).to eq(1)
+      expect(droplets.first.size.price_monthly).to eq(5)
+      expect(droplets.first.size.price_hourly).to eq(0.00743999984115362)
+      expect(droplets.first.size.regions).to include('nyc1', 'nyc2')
+      expect(droplets.first.size.available).to be(true)
+      expect(droplets.first.size.description).to eq('Basic')
+
       check_droplet(droplets.first, %w[tag-1 tag-2])
     end
 
@@ -101,6 +112,18 @@ RSpec.describe DropletKit::DropletResource do
       stub_do_api('/v2/droplets/20', :get).to_return(body: api_fixture('droplets/find'))
       droplet = resource.find(id: 20)
       expect(droplet).to be_a(DropletKit::Droplet)
+
+      expect(droplet.size).to be_a(DropletKit::Size)
+      expect(droplet.size.memory).to eq(1024)
+      expect(droplet.size.vcpus).to eq(1)
+      expect(droplet.size.disk).to eq(25)
+      expect(droplet.size.transfer).to eq(1)
+      expect(droplet.size.price_monthly).to eq(5)
+      expect(droplet.size.price_hourly).to eq(0.00743999984115362)
+      expect(droplet.size.regions).to include('nyc1', 'nyc2')
+      expect(droplet.size.available).to be(true)
+      expect(droplet.size.description).to eq('Basic')
+
       check_droplet(droplet, %w[tag-1 tag-2])
     end
 


### PR DESCRIPTION
This PR is in relation to an issue I previously opened https://github.com/digitalocean/droplet_kit/issues/306. This PR attempts to address droplet kit not including a SizeMapping when retrieving a list of droplets (`client.droplets.all`) or a specific droplet (`client.droplets.find(id: SOME_ID)`).  According to the API reference for [droplets_list](https://docs.digitalocean.com/reference/api/api-reference/#operation/droplets_list) and [droplets_get](https://docs.digitalocean.com/reference/api/api-reference/#operation/droplets_get), the response examples include a size object in the format below, but this gets set as `nil` in the droplet mapping.
```
"size": {
  "slug": "s-1vcpu-1gb",
  "memory": 1024,
  "vcpus": 1,
  "disk": 25,
  "transfer": 1,
  "price_monthly": 5,
  "price_hourly": 0.00743999984115362,
  "regions": [
    "nyc2",
  ],
  "available": true,
  "description": "Basic"
}
```

I have added a read `size` attribute that includes the SizeMapping to the droplet mapping.

For the specs, I decided to add expect statements under the specific describe blocks for `#all` and `#find` since this is a ':read' attribute and there is already an existing `:create` attribute named `size` that is NOT a SizeMapping. Placing these expect statements under the `check_droplet` function will cause some conflicts and failures since the function is called on all `it` definitions, both read and create. The "create" `size` attribute is just a string that is the size slug. But when accessing read resources for droplets, it returns a size object. Side Note: Would it make more sense for the API to return `size_slug` on create operations for droplets instead of having the `size` attribute return two different types based on whether it's a read or write operation?