### PR TITLE
Fix two new rubocop offenses.

### DIFF
--- a/lib/tasks/resource_doc.rake
+++ b/lib/tasks/resource_doc.rake
@@ -25,7 +25,7 @@ namespace :doc do
       puts 'Actions supported: '
       puts
       klass._resources.each do |action|
-        action_options = action.path.scan(/:[\w_\-]+/i)
+        action_options = action.path.scan(/:[\w_-]+/i)
         params = []
 
         if action.body&.arity&.positive?

--- a/spec/lib/droplet_kit/resources/database_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/database_resource_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe DropletKit::DatabaseResource do
       expect(database_cluster.db_names).to eq(['defaultdb'])
       expect(database_cluster.maintenance_window.day).to eq('saturday')
       expect(database_cluster.maintenance_window.hour).to eq('08:45:12')
-      expect(database_cluster.maintenance_window.pending).to be(true)
+      expect(database_cluster.maintenance_window.pending).to be(true) # rubocop:disable RSpec/PendingWithoutReason https://github.com/rubocop/rubocop-rspec/pull/1516
       expect(database_cluster.maintenance_window.description.first).to eq('Update TimescaleDB to version 1.2.1')
       expect(database_cluster.maintenance_window.description.last).to eq('Upgrade to PostgreSQL 11.2 and 10.7 bugfix releases')
     end


### PR DESCRIPTION
In https://github.com/digitalocean/droplet_kit/pull/307 we are seeing two new rubocop offenses. These checks were added in recent rubocop and rubocop-rspec releases. One is a false positive that will be fixed in an upcoming rubocop-rspec release. This change gets us green again.

```
| Offenses:
| 
| lib/tasks/resource_doc.rake:28:49: C: [Correctable] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
|         action_options = action.path.scan(/:[\w_\-]+/i)
|                                                 ^^
| spec/lib/droplet_kit/resources/database_resource_spec.rb:45:14: C: RSpec/PendingWithoutReason: Give the reason for pending.
|       expect(database_cluster.maintenance_window.pending).to be(true)
|              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
| 
| 212 files inspected, 2 offenses detected, 1 offense autocorrectable
```