### PR TITLE
account: add 'name' field in response

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,15 @@ Gemspec/RequireMFA:
 Gemspec/RubyVersionGlobalsUsage:
   Enabled: false
 
+RSpec/IndexedLet:
+  Enabled: false
+
+RSpec/MatchArray:
+  Enabled: false
+
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
 RSpec:
   Language:
     Expectations:

--- a/lib/droplet_kit/mappings/account_mapping.rb
+++ b/lib/droplet_kit/mappings/account_mapping.rb
@@ -15,6 +15,21 @@ module DropletKit
         property :email
         property :uuid
         property :email_verified
+        property :team
+      end
+    end
+  end
+
+  class AccountTeamMapping
+    include Kartograph::DSL
+
+    kartograph do
+      root_key singular: 'team', scopes: [:read]
+      mapping AccountTeam
+
+      scoped :read do
+        property :uuid
+        property :name
       end
     end
   end

--- a/lib/droplet_kit/mappings/account_mapping.rb
+++ b/lib/droplet_kit/mappings/account_mapping.rb
@@ -11,6 +11,7 @@ module DropletKit
       scoped :read do
         property :droplet_limit
         property :floating_ip_limit
+        property :name
         property :email
         property :uuid
         property :email_verified

--- a/lib/droplet_kit/models/account.rb
+++ b/lib/droplet_kit/models/account.rb
@@ -8,5 +8,11 @@ module DropletKit
     attribute :email
     attribute :uuid
     attribute :email_verified
+    attribute :team
+  end
+
+  class AccountTeam < BaseModel
+    attribute :uuid
+    attribute :name
   end
 end

--- a/lib/droplet_kit/models/account.rb
+++ b/lib/droplet_kit/models/account.rb
@@ -4,6 +4,7 @@ module DropletKit
   class Account < BaseModel
     attribute :droplet_limit
     attribute :floating_ip_limit
+    attribute :name
     attribute :email
     attribute :uuid
     attribute :email_verified

--- a/spec/fixtures/account/info.json
+++ b/spec/fixtures/account/info.json
@@ -1,6 +1,7 @@
 {
     "account": {
         "droplet_limit": 200,
+        "name": "Sammy the Shark",
         "email": "droplet_kit@digitalocean.com",
         "uuid": "alksdjfhlakjdsfh12983712",
         "email_verified": true

--- a/spec/fixtures/account/info.json
+++ b/spec/fixtures/account/info.json
@@ -1,9 +1,13 @@
 {
     "account": {
         "droplet_limit": 200,
-        "name": "Sammy the Shark",
         "email": "droplet_kit@digitalocean.com",
+        "name": "Sammy the Shark",
         "uuid": "alksdjfhlakjdsfh12983712",
-        "email_verified": true
+        "email_verified": true,
+        "team": {
+            "uuid": "00000000-0000-4000-00000000000000000",
+            "name": "My Team"
+        }
     }
 }

--- a/spec/lib/droplet_kit/resources/account_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/account_resource_spec.rb
@@ -20,9 +20,10 @@ RSpec.describe DropletKit::AccountResource do
       expect(account_info.droplet_limit).to eq(parsed['account']['droplet_limit'])
       expect(account_info.floating_ip_limit).to eq(parsed['account']['floating_ip_limit'])
       expect(account_info.email).to eq(parsed['account']['email'])
-      expect(account_info.email).to eq(parsed['account']['email'])
+      expect(account_info.name).to eq(parsed['account']['name'])
       expect(account_info.uuid).to eq(parsed['account']['uuid'])
       expect(account_info.email_verified).to eq(parsed['account']['email_verified'])
+      expect(account_info.team).to eq(parsed['account']['team'])
     end
 
     it_behaves_like 'resource that handles common errors' do

--- a/spec/lib/droplet_kit/resources/account_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/account_resource_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe DropletKit::AccountResource do
       expect(account_info.droplet_limit).to eq(parsed['account']['droplet_limit'])
       expect(account_info.floating_ip_limit).to eq(parsed['account']['floating_ip_limit'])
       expect(account_info.email).to eq(parsed['account']['email'])
+      expect(account_info.email).to eq(parsed['account']['email'])
       expect(account_info.uuid).to eq(parsed['account']['uuid'])
       expect(account_info.email_verified).to eq(parsed['account']['email_verified'])
     end

--- a/spec/lib/droplet_kit/resources/database_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/database_resource_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe DropletKit::DatabaseResource do
       expect(database_cluster.db_names).to eq(['defaultdb'])
       expect(database_cluster.maintenance_window.day).to eq('saturday')
       expect(database_cluster.maintenance_window.hour).to eq('08:45:12')
-      expect(database_cluster.maintenance_window.pending).to be(true) # rubocop:disable RSpec/PendingWithoutReason https://github.com/rubocop/rubocop-rspec/pull/1516
+      expect(database_cluster.maintenance_window.pending).to be(true)
       expect(database_cluster.maintenance_window.description.first).to eq('Update TimescaleDB to version 1.2.1')
       expect(database_cluster.maintenance_window.description.last).to eq('Upgrade to PostgreSQL 11.2 and 10.7 bugfix releases')
     end


### PR DESCRIPTION
Adds the new `name` field on the account response.