### PR TITLE
retry requests when rate limit reached

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ruby: [ 2.5, 2.6, 2.7, "3.0", 3.1, 3.2 ] # "x.0" to workaround: https://github.com/ruby/setup-ruby/issues/252
+        ruby: [ 2.6, 2.7, "3.0", 3.1, 3.2 ] # "x.0" to workaround: https://github.com/ruby/setup-ruby/issues/252
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ require 'droplet_kit'
 client = DropletKit::Client.new(access_token: 'YOUR_TOKEN', user_agent: 'custom')
 ```
 
+### Automatically Retry Rate Limited Requests
+
+By default, DropletKit will handle requests that are rate limited by the DigitalOcean API's [burst limit](https://docs.digitalocean.com/reference/api/api-reference/#section/Introduction/Rate-Limit). When the burst rate limit is reached, DropletKit will wait according to the value of the API response's `Retry-After` header. Typically the wait time is less than one minute. When the hourly rate limit is hit, an error is raised.
+
+By default, DropletKit will retry a rate limited request three times before returning an error. If you would like to disable the retry behavior altogether, and instead raise an error when any rate limit is reached, you can set the `retry_max` config value to zero.
+
+DropletKit will also wait zero seconds until retrying a request after the `Retry-After` time has elapsed by default. To change this, set the `retry_wait_min` to a different value.
+
+```ruby
+require 'droplet_kit'
+client = DropletKit::Client.new(access_token: 'YOUR_TOKEN', retry_max: 3, retry_wait_min: 1)
+```
+
 ## Design
 
 DropletKit follows a strict design of resources as methods on your client. For examples, for droplets, you will call your client like this:

--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'faraday', '>= 0.15'
+  spec.add_dependency 'faraday-retry', '~> 2.2.0'
   spec.add_dependency 'kartograph', '~> 0.2.8'
   spec.add_dependency 'resource_kit', '~> 0.1.5'
   spec.add_dependency 'virtus', '>= 1.0.3', '<= 3'

--- a/lib/droplet_kit/client.rb
+++ b/lib/droplet_kit/client.rb
@@ -31,17 +31,19 @@ module DropletKit
         req.adapter :net_http
         req.options.open_timeout = open_timeout
         req.options.timeout = timeout
-        req.request :retry, {
-          max: @retry_max,
-          interval: @retry_wait_min,
-          retry_statuses: [429],
-          # faraday-retry supports both the Retry-After and RateLimit-Reset
-          # headers, however, it favours the RateLimit-Reset one. To force it
-          # to use the Retry-After header, we override the header that it
-          # expects for the RateLimit-Reset header to something that we know
-          # we don't set.
-          rate_limit_reset_header: 'undefined'
-        }
+        unless retry_max.zero?
+          req.request :retry, {
+            max: @retry_max,
+            interval: @retry_wait_min,
+            retry_statuses: [429],
+            # faraday-retry supports both the Retry-After and RateLimit-Reset
+            # headers, however, it favours the RateLimit-Reset one. To force it
+            # to use the Retry-After header, we override the header that it
+            # expects for the RateLimit-Reset header to something that we know
+            # we don't set.
+            rate_limit_reset_header: 'undefined'
+          }
+        end
       end
     end
 
@@ -108,6 +110,11 @@ module DropletKit
           content_type: 'application/json',
           authorization: "Bearer #{access_token}",
           user_agent: "#{user_agent} #{default_user_agent}".strip
+        },
+        request: {
+          context: {
+            retry_max: @retry_max
+          }
         }
       }
     end

--- a/lib/droplet_kit/error_handling_resourcable.rb
+++ b/lib/droplet_kit/error_handling_resourcable.rb
@@ -8,7 +8,7 @@ module ErrorHandlingResourcable
         when 200...299
           next
         when 429
-          unless response.headers.key?('Retry-After')
+          unless response.headers.key?('Retry-After') && !connection.options.context.key?(:retry_max)
             error = DropletKit::RateLimitReached.new("#{response.status}: #{response.body}")
             error.limit = response.headers['RateLimit-Limit']
             error.remaining = response.headers['RateLimit-Remaining']

--- a/lib/droplet_kit/error_handling_resourcable.rb
+++ b/lib/droplet_kit/error_handling_resourcable.rb
@@ -7,12 +7,6 @@ module ErrorHandlingResourcable
         case response.status
         when 200...299
           next
-        when 429
-          error = DropletKit::RateLimitReached.new("#{response.status}: #{response.body}")
-          error.limit = response.headers['RateLimit-Limit']
-          error.remaining = response.headers['RateLimit-Remaining']
-          error.reset_at = response.headers['RateLimit-Reset']
-          raise error
         else
           raise DropletKit::Error, "#{response.status}: #{response.body}"
         end

--- a/lib/droplet_kit/error_handling_resourcable.rb
+++ b/lib/droplet_kit/error_handling_resourcable.rb
@@ -7,6 +7,14 @@ module ErrorHandlingResourcable
         case response.status
         when 200...299
           next
+        when 429
+          unless response.headers.key?('Retry-After')
+            error = DropletKit::RateLimitReached.new("#{response.status}: #{response.body}")
+            error.limit = response.headers['RateLimit-Limit']
+            error.remaining = response.headers['RateLimit-Remaining']
+            error.reset_at = response.headers['RateLimit-Reset']
+            raise error
+          end
         else
           raise DropletKit::Error, "#{response.status}: #{response.body}"
         end

--- a/spec/lib/droplet_kit/client_spec.rb
+++ b/spec/lib/droplet_kit/client_spec.rb
@@ -51,6 +51,26 @@ RSpec.describe DropletKit::Client do
 
       expect(client.timeout).to eq(timeout)
     end
+
+    it 'allows retry max to be set' do
+      retry_max = 10
+      client = described_class.new(
+        'access_token' => 'my-token',
+        'retry_max' => retry_max
+      )
+
+      expect(client.retry_max).to eq(retry_max)
+    end
+
+    it 'allows retry wait min to be set' do
+      retry_wait_min = 3
+      client = described_class.new(
+        'access_token' => 'my-token',
+        'retry_wait_min' => retry_wait_min
+      )
+
+      expect(client.retry_wait_min).to eq(retry_wait_min)
+    end
   end
 
   describe '#method_missing' do

--- a/spec/lib/droplet_kit/client_spec.rb
+++ b/spec/lib/droplet_kit/client_spec.rb
@@ -71,6 +71,19 @@ RSpec.describe DropletKit::Client do
 
       expect(client.retry_wait_min).to eq(retry_wait_min)
     end
+
+    it 'does not handle rate limited requests when retry max is zero' do
+      client = described_class.new(retry_max: 0)
+
+      stub_do_api('/v2/account', :get).to_return(body: { id: :rate_limit, message: '429' }.to_json, status: 429, headers: {
+                                                   'RateLimit-Limit' => 1200,
+                                                   'RateLimit-Remaining' => 1193,
+                                                   'RateLimit-Reset' => 1_402_425_459,
+                                                   'Retry-After' => 0
+                                                 })
+
+      expect { client.account.send(:info).to_a }.to raise_exception(DropletKit::RateLimitReached)
+    end
   end
 
   describe '#method_missing' do

--- a/spec/lib/droplet_kit/resources/account_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/account_resource_spec.rb
@@ -31,5 +31,11 @@ RSpec.describe DropletKit::AccountResource do
       let(:method) { :get }
       let(:action) { :info }
     end
+
+    it_behaves_like 'resource that handles rate limit retries' do
+      let(:path) { '/v2/account' }
+      let(:method) { :get }
+      let(:action) { :info }
+    end
   end
 end

--- a/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
+++ b/spec/lib/droplet_kit/resources/droplet_resource_spec.rb
@@ -133,6 +133,13 @@ RSpec.describe DropletKit::DropletResource do
       let(:action) { :find }
       let(:arguments) { { id: 123 } }
     end
+
+    it_behaves_like 'resource that handles rate limit retries' do
+      let(:path) { '/v2/droplets/123' }
+      let(:method) { :get }
+      let(:action) { :find }
+      let(:arguments) { { id: 123 } }
+    end
   end
 
   describe '#create' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'simplecov'
 SimpleCov.start
 
 require 'faraday'
+require 'faraday/retry'
 require 'addressable/uri'
 require 'droplet_kit'
 require 'webmock/rspec'

--- a/spec/support/shared_examples/common_errors.rb
+++ b/spec/support/shared_examples/common_errors.rb
@@ -3,22 +3,6 @@
 shared_examples_for 'resource that handles common errors' do
   let(:arguments) { {} }
 
-  it 'handles rate limit' do
-    response_body = { id: :rate_limit, message: 'Too much!!!' }
-    stub_do_api(path, method).to_return(body: response_body.to_json, status: 429, headers: {
-                                          'RateLimit-Limit' => 1200,
-                                          'RateLimit-Remaining' => 1193,
-                                          'RateLimit-Reset' => 1_402_425_459
-                                        })
-
-    expect { resource.send(action, arguments).to_a }.to raise_exception(DropletKit::Error) do |exception|
-      expect(exception.message).to match(/#{response_body[:message]}/)
-      expect(exception.limit).to eq 1200
-      expect(exception.remaining).to eq 1193
-      expect(exception.reset_at).to eq '1402425459'
-    end
-  end
-
   it 'handles unauthorized' do
     response_body = { id: :unauthorized, message: 'Nuh uh.' }
 

--- a/spec/support/shared_examples/common_errors.rb
+++ b/spec/support/shared_examples/common_errors.rb
@@ -3,6 +3,22 @@
 shared_examples_for 'resource that handles common errors' do
   let(:arguments) { {} }
 
+  it 'handles rate limit when retry-after is not present' do
+    response_body = { id: :rate_limit, message: 'Too much!!!' }
+    stub_do_api(path, method).to_return(body: response_body.to_json, status: 429, headers: {
+                                          'RateLimit-Limit' => 1200,
+                                          'RateLimit-Remaining' => 1193,
+                                          'RateLimit-Reset' => 1_402_425_459
+                                        })
+
+    expect { resource.send(action, arguments).to_a }.to raise_exception(DropletKit::Error) do |exception|
+      expect(exception.message).to match(/#{response_body[:message]}/)
+      expect(exception.limit).to eq 1200
+      expect(exception.remaining).to eq 1193
+      expect(exception.reset_at).to eq '1402425459'
+    end
+  end
+
   it 'handles unauthorized' do
     response_body = { id: :unauthorized, message: 'Nuh uh.' }
 

--- a/spec/support/shared_examples/rate_limit_retry.rb
+++ b/spec/support/shared_examples/rate_limit_retry.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+shared_examples_for 'resource that handles rate limit retries' do
+  let(:arguments) { {} }
+
+  it 'handles rate limit' do
+    response_body = { id: :rate_limit, message: 'example' }
+    stub_do_api(path, method).to_return(
+      [
+        {
+          body: nil,
+          status: 429,
+          headers: {
+            'RateLimit-Limit' => 1200,
+            'RateLimit-Remaining' => 1193,
+            'RateLimit-Reset' => 1_402_425_459,
+            'Retry-After' => 0 # Retry immediately in tests.
+          }
+        },
+        {
+          body: response_body.to_json,
+          status: 200,
+          headers: {
+            'RateLimit-Limit' => 1200,
+            'RateLimit-Remaining' => 1192,
+            'RateLimit-Reset' => 1_402_425_459
+          }
+        }
+      ]
+    )
+
+    expect { resource.send(action, arguments) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Adds support for retrying requests that fail with 429 using the `Retry-After` header, similar to what we do in godo.