### PR TITLE
Make spec compatible with current ruby-head (future ruby-3.5)

### DIFF
--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -19,10 +19,12 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5.0'
 
+  spec.add_dependency 'base64', '~> 0'
   spec.add_dependency 'bigdecimal'
   spec.add_dependency 'faraday', '>= 0.15'
   spec.add_dependency 'faraday-retry', '~> 2.2.0'
   spec.add_dependency 'kartograph', '~> 0.2.8'
+  spec.add_dependency 'ostruct', '~> 0'
   spec.add_dependency 'resource_kit', '~> 0.1.5'
   spec.add_dependency 'virtus', '>= 1.0.3', '<= 3'
 


### PR DESCRIPTION
Current `ruby-head` what become `ruby-3.5` at end of year requires `base64` and `ostruct` gem clearly stated as dependency

Seems like at least `ostruct` requirement coming from `virtus` gem, but this gem is deprecated, so I don't think we should bother there