### PR TITLE
Properly camelize vpc urn

### DIFF
--- a/lib/droplet_kit/utils.rb
+++ b/lib/droplet_kit/utils.rb
@@ -4,6 +4,8 @@ module DropletKit
   module Utils
     def self.camelize(term)
       string = term.to_s
+      return 'VPC' if string == 'vpc'
+
       string.sub!(/^[a-z\d]*/, &:capitalize)
       string.gsub!(%r{(?:_|(/))([a-z\d]*)}i) { Regexp.last_match(2).capitalize }
       string.gsub!('/', '::')

--- a/spec/lib/droplet_kit/models/base_model_spec.rb
+++ b/spec/lib/droplet_kit/models/base_model_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe DropletKit::BaseModel do
       expect(described_class.valid_urn?(urn)).to be true
     end
 
+    it 'is true when there is a constant matching the collection with acronym' do
+      urn = 'do:vpc:123456'
+
+      expect(described_class.valid_urn?(urn)).to be true
+    end
+
     it 'is true when it is an unsupported collection' do
       urn = 'do:space:234567'
 


### PR DESCRIPTION
### Issue:

`cannot assign resource without valid urn: do:vpc:32844355-78cd-4557-bb11-1ff20a54c000`

### Bug:

`.camelize` method turn `vpc` to unexistent `Vpc` class, whereas `VPC` is a class name

### Fix:

Add manual inflection for vpc camelize
