### PR TITLE
Add Ruby 4.0 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ruby: [ 2.6, 2.7, "3.0", 3.1, 3.2 , 3.3] # "x.0" to workaround: https://github.com/ruby/setup-ruby/issues/252
+        ruby: [ 2.6, 2.7, "3.0", 3.1, 3.2 , 3.3, 3.4, "4.0"] # "x.0" to workaround: https://github.com/ruby/setup-ruby/issues/252
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/droplet_kit.gemspec
+++ b/droplet_kit.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bigdecimal'
   spec.add_dependency 'faraday', '>= 0.15'
-  spec.add_dependency 'faraday-retry', '~> 2.2.0'
+  spec.add_dependency 'ostruct'
+  spec.add_dependency 'faraday-retry', '~> 2.2'
   spec.add_dependency 'kartograph', '~> 0.2.8'
   spec.add_dependency 'resource_kit', '~> 0.1.5'
   spec.add_dependency 'virtus', '>= 1.0.3', '<= 3'
@@ -43,5 +44,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-packaging', '>= 0.5.1'
   spec.add_development_dependency 'rubocop-rake', '>= 0.6.0'
 
-  spec.add_development_dependency 'webmock', '~> 3.8.0'
+  spec.add_development_dependency 'webmock', '~> 3.8'
 end

--- a/spec/lib/droplet_kit/models/base_model_spec.rb
+++ b/spec/lib/droplet_kit/models/base_model_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe DropletKit::BaseModel do
   describe '#inspect' do
     it 'returns the information about the current user' do
       instance = resource.new(droplet_limit: 5)
-      expect(instance.inspect).to include('<SomeModel')
-      expect(instance.inspect).to include('@droplet_limit=>5')
-      expect(instance.inspect).to include('<SomeModel {:@droplet_limit=>5}>')
+      expect(instance.inspect).to include('SomeModel')
+      expect(instance.inspect).to include('droplet_limit')
+      expect(instance.inspect).to include('5')
     end
   end
 end


### PR DESCRIPTION
Changes:

1. Add `ostruct` as explicit dependency
   - Deprecated and no longer auto-loaded since Ruby 3.4.0
   - Required by the `virtus` gem

2. Relax `faraday-retry` constraint from `~> 2.2.0` to `~> 2.2`
   - Allows 2.4.0+ which removed the `ruby < 4` version constraint
   - Previous constraint only allowed 2.2.x which has `ruby < 4` limit

3. Relax `webmock` constraint from `~> 3.8.0` to `~> 3.8`
   - Allows 3.26.1+ which includes Ruby 4 compatibility fixes

4. Update inspect test in base_model_spec.rb
   - Ruby 4 changed inspect output format from `{:@attr=>val}` to `{"@attr": val}`
   - Made assertions format-agnostic to work with both Ruby 3 and 4

Tested with Ruby 4.0.1 - all 443 specs pass.